### PR TITLE
Speed up model load by skipping init on strict load

### DIFF
--- a/opendde/model/triangular/layers.py
+++ b/opendde/model/triangular/layers.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2026 Aureka AI Research
 # Copyright 2021 AlQuraishi Laboratory
 
+import contextlib
 import math
 import os
+import sys
 from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
@@ -91,6 +93,36 @@ def gating_init_(weights: torch.Tensor) -> None:
 
 def normal_init_(weights: torch.Tensor) -> None:
     torch.nn.init.kaiming_normal_(weights, nonlinearity="linear")
+
+
+@contextlib.contextmanager
+def skip_random_init():
+    """
+    Skips random weight initialization.
+
+    Skips the following initialization work:
+    * trunc_normal_init_ in opendde.model.triangular.layers
+    * trunc_normal_init_ in opendde.model.modules.primitives
+    * reset_parameters in torch.nn.Linear which includes kaiminig_uniform_
+    """
+    def _noop_init(*_args, **_kwargs):
+        pass
+
+    from opendde.model.modules import primitives
+
+    originals = [
+        (sys.modules[__name__], "trunc_normal_init_"),
+        (primitives, "trunc_normal_init_"),
+        (torch.nn.Linear, "reset_parameters"),
+    ]
+    saved = [(obj, attr, getattr(obj, attr)) for obj, attr in originals]
+    try:
+        for obj, attr in originals:
+            setattr(obj, attr, _noop_init)
+        yield
+    finally:
+        for obj, attr, value in saved:
+            setattr(obj, attr, value)
 
 
 class OpenfoldLinear(nn.Linear):

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -34,6 +34,7 @@ from opendde.distributed.foldcp.metrics import (
     measure_foldcp_stage,
 )
 from opendde.model.opendde import OpenDDE
+from opendde.model.triangular.layers import skip_random_init
 from opendde.utils.distributed import DIST_WRAPPER
 from opendde.utils.download import (
     download_inference_cache,
@@ -124,7 +125,8 @@ class InferenceRunner(object):
             self.init_env()
             _download_inference_assets(self.configs)
             self.init_basics()
-            self.init_model()
+            with skip_random_init() if self.configs.load_strict else nullcontext():
+                self.init_model()
             self.load_checkpoint()
             self.init_dumper(
                 need_atom_confidence=self.configs.need_atom_confidence,


### PR DESCRIPTION
Model load spends significant time on initializing layers with a slow truncnorm plus an implicit kaiminig_uniform_ of torch.nn.Linear. But this work is discarded at construction when the parameters are overwritten by the actual model weights with load_state_dict.

**Changes**
This commit monkey patches trunc_normal_init_ and nn.Linear's reset_parameters to noops during inference via a skip_random_init context manager.

On my machine, this leads to a reduction of ~1 minute. A similar patch has already been merged into openfold-3 (PR 220).