### PR TITLE
Support explicit indexed mmCIF templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ User-facing changes to OpenDDE are documented here.
 
 ## [Unreleased]
 
-No changes yet.
+### Added
+
+- Added sparse indexed mmCIF templates through `proteinChain.templates`.
 
 ## [1.1.0] - 2026-08-16
 

--- a/docs/infer_json_format.md
+++ b/docs/infer_json_format.md
@@ -63,6 +63,61 @@ match `count`.
 - `templatesPath`: optional template hits file (`.a3m` or `.hhr`), used only with
   `--use_template true`.
 
+### Protein template modes
+
+`--use_template false` disables template features for every chain. With
+`--use_template true`, each protein chain independently selects one mode:
+
+| Chain fields | Behavior |
+| --- | --- |
+| Neither `templates` nor `templatesPath` | Eligible for the existing automatic template-search pipeline. |
+| `templatesPath` | Use the existing HHR/A3M search-hit pipeline. |
+| `templates: []` | Explicitly disable templates for this chain. Automatic search does not overwrite it. |
+| Non-empty `templates` | Use the supplied structures and index mappings exactly; automatic search does not overwrite them. |
+
+Do not set `templates` and `templatesPath` on the same chain. Existing inputs
+that omit `templates` retain their previous automatic-search or
+`templatesPath` behavior.
+
+Each explicit template is an object with this shape:
+
+```json
+{
+  "mmcifPath": "templates/target.cif",
+  "queryIndices": [0, 1, 4, 5],
+  "templateIndices": [0, 1, 2, 3]
+}
+```
+
+- Set exactly one of `mmcifPath` or `mmcif`. `mmcif` contains the complete
+  mmCIF document as a JSON string. A relative `mmcifPath` is resolved from the
+  directory containing the input JSON file.
+- `queryIndices` and `templateIndices` are paired, zero-based positions in the
+  query sequence and parsed template polymer sequence, respectively. They are
+  not PDB author residue numbers.
+- Both arrays must be non-empty, have equal length, contain only non-negative
+  integers, and stay within their corresponding sequences. `queryIndices` must
+  be unique; array order defines the residue pairs.
+- The pair at each array position defines one residue mapping. Query residues
+  omitted from `queryIndices` remain untemplated, enabling sparse conditioning.
+- The mmCIF must contain exactly one protein polymer chain and a valid PDBx
+  revision date.
+- OpenDDE uses at most four templates per protein chain, taking the first four
+  in JSON order. Entries after the first four are ignored.
+- Explicit templates bypass the automatic search-hit release-date cutoff and
+  near-duplicate filtering. The caller is responsible for choosing suitable
+  template structures and enforcing any dataset cutoff.
+
+When every template-enabled protein chain uses explicit `templates` (or
+`templates: []`), template processing does not invoke automatic search,
+Kalign, a template-search database or cache, or template-network access. Normal
+checkpoint and common runtime assets are still required. A mixed input still
+needs search infrastructure for any chain using automatic search or
+`templatesPath`.
+
+See the runnable sparse example in
+[`examples/example_explicit_template.json`](../examples/example_explicit_template.json).
+
 ## `dnaSequence`
 
 ```json

--- a/docs/msa_template_pipeline.md
+++ b/docs/msa_template_pipeline.md
@@ -131,4 +131,5 @@ Override downloads:
 - RNA MSA: `nhmmer`, `hmmalign`, `hmmbuild`.
 - Search database decompression: `zstd` command, or the optional Python
   `zstandard` package for Python auto-downloads.
-- Template inference: `kalign`.
+- Search-hit template inference: `kalign`. Explicit indexed templates do not
+  use it.

--- a/examples/example_explicit_template.json
+++ b/examples/example_explicit_template.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "2lwu_explicit_sparse_template",
+    "modelSeeds": [101],
+    "sequences": [
+      {
+        "proteinChain": {
+          "sequence": "GHCIPTTSGPICLRD",
+          "count": 1,
+          "templates": [
+            {
+              "mmcifPath": "2lwu.cif",
+              "queryIndices": [0, 2, 4, 6, 8, 10, 12, 14],
+              "templateIndices": [0, 2, 4, 6, 8, 10, 12, 14]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/opendde/data/inference/infer_dataloader.py
+++ b/opendde/data/inference/infer_dataloader.py
@@ -15,7 +15,11 @@ from torch.utils.data import DataLoader, Dataset, DistributedSampler
 from opendde.data.core import ccd
 from opendde.data.inference.json_to_feature import SampleDictToFeatures
 from opendde.data.msa.msa_featurizer import InferenceMSAFeaturizer
-from opendde.data.template.template_featurizer import InferenceTemplateFeaturizer
+from opendde.data.template.template_featurizer import (
+    MAX_TEMPLATES,
+    InferenceTemplateFeaturizer,
+)
+from opendde.data.template.template_input import needs_template_search
 from opendde.data.template.template_utils import TemplateHitFeaturizer
 from opendde.data.utils import data_type_transform, make_dummy_feature
 from opendde.utils.distributed import DIST_WRAPPER
@@ -74,7 +78,7 @@ class InferenceDataset(Dataset):
         )
         with open(self.input_json_path, "r") as f:
             self.inputs = cast(list[dict[str, Any]], json.load(f))
-        if self.use_template:
+        if self.use_template and needs_template_search(self.inputs):
             template_mmcif_dir = configs.data.template.prot_template_mmcif_dir
             fetch_remote = configs.data.template.get("fetch_remote", True)
             if not fetch_remote:
@@ -94,7 +98,7 @@ class InferenceDataset(Dataset):
             self.online_template_featurizer = TemplateHitFeaturizer(
                 mmcif_dir=configs.data.template.prot_template_mmcif_dir,
                 template_cache_dir=configs.data.template.prot_template_cache_dir,
-                max_hits=4,
+                max_hits=MAX_TEMPLATES,
                 kalign_binary_path=configs.data.template.kalign_binary_path,
                 max_template_date="2021-09-30",
                 release_dates_path=configs.data.template.release_dates_path,
@@ -155,6 +159,7 @@ class InferenceDataset(Dataset):
             atom_array=atom_array,
             use_template=self.use_template,
             online_template_featurizer=self.online_template_featurizer,
+            json_path=self.input_json_path,
         )
         # Make dummy features for not implemented features
         dummy_feats = []

--- a/opendde/data/template/template_featurizer.py
+++ b/opendde/data/template/template_featurizer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Aureka AI Research
 import dataclasses
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Self, Sequence, TypeAlias
 
 import numpy as np
@@ -13,17 +14,25 @@ from opendde.data.constants import (
     RNA_CHAIN,
 )
 from opendde.data.msa.msa_utils import map_to_standard
-from opendde.data.template.template_parser import HHRParser, HmmsearchA3MParser
+from opendde.data.template.template_input import get_explicit_templates
+from opendde.data.template.template_parser import (
+    HHRParser,
+    HmmsearchA3MParser,
+    TemplateParser,
+)
 from opendde.data.template.template_utils import (
     TEMPLATE_FEATURES,
     DistogramFeaturesConfig,
     TemplateFeatures,
     TemplateHitFeaturizer,
+    TemplateHitProcessor,
 )
 from opendde.data.utils import pad_to
 from opendde.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+MAX_TEMPLATES = 4
 
 BatchDict: TypeAlias = dict[str, np.ndarray]
 FeatureDict: TypeAlias = Mapping[str, np.ndarray]
@@ -38,7 +47,7 @@ class TemplateFeatureAssemblyLine:
         max_templates: Maximum number of templates to include in the features.
     """
 
-    def __init__(self, max_templates: int = 4) -> None:
+    def __init__(self, max_templates: int = MAX_TEMPLATES) -> None:
         self.max_templates = max_templates
 
     def assemble(
@@ -241,11 +250,143 @@ class InferenceTemplateFeaturizer:
     """Simplified featurizer for inference, leveraging the same assembly logic."""
 
     @staticmethod
+    def _load_explicit_template_mmcif(
+        template_info: Mapping[str, Any],
+        *,
+        json_path: Optional[str],
+        template_index: int,
+    ) -> tuple[str, str]:
+        mmcif = template_info.get("mmcif")
+        mmcif_path = template_info.get("mmcifPath")
+        if mmcif is not None and mmcif_path is not None:
+            raise ValueError(
+                "Explicit template entry accepts only one of mmcif or mmcifPath."
+            )
+        if mmcif is None and mmcif_path is None:
+            raise ValueError(
+                "Explicit template entry requires either mmcif or mmcifPath."
+            )
+        if mmcif_path is not None:
+            if not isinstance(mmcif_path, str) or not mmcif_path:
+                raise ValueError(
+                    "Explicit template mmcifPath must be a non-empty string."
+                )
+            resolved_path = Path(mmcif_path)
+            if not resolved_path.is_absolute():
+                base_dir = Path(json_path).resolve().parent if json_path else Path()
+                resolved_path = (base_dir / resolved_path).resolve()
+            return resolved_path.read_text(encoding="utf-8"), resolved_path.stem
+        if not isinstance(mmcif, str) or not mmcif:
+            raise ValueError("Explicit template mmcif must be a non-empty string.")
+        return mmcif, f"template_{template_index}"
+
+    @staticmethod
+    def _validate_explicit_indices(name: str, value: Any) -> list[int]:
+        if not isinstance(value, list):
+            raise ValueError(
+                f"Explicit template {name} must be a list of JSON integers."
+            )
+        if not value:
+            raise ValueError(f"Explicit template {name} must be non-empty.")
+        if any(type(index) is not int for index in value):
+            raise ValueError(f"Explicit template {name} must contain JSON integers.")
+        if any(index < 0 for index in value):
+            raise ValueError("Explicit template indices must be non-negative integers.")
+        return value
+
+    @staticmethod
+    def _build_explicit_template_features(
+        *,
+        query_seq: str,
+        raw_templates: list[Any],
+        json_path: Optional[str],
+    ) -> list[Dict[str, Any]]:
+        if not isinstance(raw_templates, list):
+            raise TypeError("proteinChain.templates must be a list.")
+
+        processor = TemplateHitProcessor(mmcif_dir="")
+        explicit_features: list[Dict[str, Any]] = []
+        for template_index, template_info in enumerate(raw_templates[:MAX_TEMPLATES]):
+            if not isinstance(template_info, Mapping):
+                raise TypeError(
+                    "Each explicit template entry must be an object with "
+                    "mmcif/mmcifPath + queryIndices/templateIndices."
+                )
+
+            mmcif_string, file_id = (
+                InferenceTemplateFeaturizer._load_explicit_template_mmcif(
+                    template_info,
+                    json_path=json_path,
+                    template_index=template_index,
+                )
+            )
+            query_indices = InferenceTemplateFeaturizer._validate_explicit_indices(
+                "queryIndices", template_info.get("queryIndices")
+            )
+            template_indices = InferenceTemplateFeaturizer._validate_explicit_indices(
+                "templateIndices", template_info.get("templateIndices")
+            )
+            if len(set(query_indices)) != len(query_indices):
+                raise ValueError("Explicit template queryIndices must be unique.")
+            if len(query_indices) != len(template_indices):
+                raise ValueError(
+                    "Explicit template queryIndices and templateIndices must have "
+                    "the same length."
+                )
+            if max(query_indices) >= len(query_seq):
+                raise ValueError(
+                    "Explicit template queryIndices exceed query sequence length."
+                )
+
+            parsed = TemplateParser.parse(
+                file_id=file_id,
+                mmcif_string=mmcif_string,
+                auth_chain_id=None,
+            )
+            if parsed.mmcif_object is None:
+                raise ValueError(f"Failed to parse explicit template mmCIF: {file_id}")
+
+            chain_items = list(parsed.mmcif_object.chain_to_seqres.items())
+            if len(chain_items) != 1:
+                raise ValueError(
+                    "Explicit template mmCIF must contain exactly one protein chain."
+                )
+            chain_id, template_seq = chain_items[0]
+            if max(template_indices) >= len(template_seq):
+                raise ValueError(
+                    "Explicit template templateIndices exceed template sequence length."
+                )
+
+            release_date = parsed.mmcif_object.header.get("release_date")
+            if not release_date:
+                raise ValueError(
+                    "Explicit template mmCIF is missing "
+                    "_pdbx_audit_revision_history.revision_date."
+                )
+            mapping = dict(zip(query_indices, template_indices))
+            features, _ = processor._extract_template_features(
+                parsed.mmcif_object,
+                file_id,
+                mapping,
+                template_seq,
+                query_seq,
+                chain_id,
+                minimum_atom_count=1,
+            )
+            features["template_release_date"] = np.array(
+                release_date.encode(), dtype=object
+            )
+            explicit_features.append(features)
+
+        return explicit_features
+
+    @staticmethod
     def make_template_feature(
         bioassembly: Sequence[Mapping[str, Any]],
         atom_array: AtomArray,
         use_template: bool = True,
         online_template_featurizer: Optional[TemplateHitFeaturizer] = None,
+        json_path: Optional[str] = None,
     ) -> Dict[str, np.ndarray]:
         """
         Generates template features during inference.
@@ -255,6 +396,7 @@ class InferenceTemplateFeaturizer:
             atom_array: Parsed atom structure.
             use_template: Whether to use templates.
             online_template_featurizer: Featurizer for processing template hits.
+            json_path: Input JSON path used to resolve relative mmCIF paths.
 
         Returns:
             Dictionary of template features.
@@ -268,6 +410,7 @@ class InferenceTemplateFeaturizer:
 
         for eid, info in enumerate(bioassembly):
             seq, count, ctype, t_path = "", 0, LIGAND_CHAIN_TYPES, ""
+            explicit_templates = None
 
             if "proteinChain" in info:
                 c = info["proteinChain"]
@@ -277,6 +420,8 @@ class InferenceTemplateFeaturizer:
                     PROTEIN_CHAIN,
                     c.get("templatesPath", ""),
                 )
+                if use_template:
+                    explicit_templates = get_explicit_templates(c)
             elif "rnaSequence" in info:
                 c = info["rnaSequence"]
                 seq, count, ctype = c["sequence"], c["count"], RNA_CHAIN
@@ -290,7 +435,15 @@ class InferenceTemplateFeaturizer:
                 count, ctype = info["ion"]["count"], LIGAND_CHAIN_TYPES
 
             templates = []
-            if t_path and use_template and online_template_featurizer:
+            if explicit_templates:
+                templates = (
+                    InferenceTemplateFeaturizer._build_explicit_template_features(
+                        query_seq=seq,
+                        raw_templates=explicit_templates,
+                        json_path=json_path,
+                    )
+                )
+            elif t_path and use_template and online_template_featurizer:
                 assert ctype == PROTEIN_CHAIN, "Only protein templates are supported."
                 with open(t_path, "r") as f:
                     content = f.read()
@@ -336,7 +489,7 @@ class InferenceTemplateFeaturizer:
 
         # Assemble features
         return (
-            TemplateFeatureAssemblyLine(max_templates=4)
+            TemplateFeatureAssemblyLine(max_templates=MAX_TEMPLATES)
             .assemble(template_meta_infos, std_idxs)
             .as_opendde_dict()
         )

--- a/opendde/data/template/template_input.py
+++ b/opendde/data/template/template_input.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+from collections.abc import Mapping
+from typing import Any
+
+
+def get_explicit_templates(protein_chain: Mapping[str, Any]) -> list[Any] | None:
+    """Return explicit templates, or None when the search pipeline applies."""
+    if "templates" not in protein_chain:
+        return None
+    if protein_chain.get("templatesPath"):
+        raise ValueError(
+            "proteinChain accepts either explicit templates or templatesPath, not both."
+        )
+    explicit_templates = protein_chain["templates"]
+    if not isinstance(explicit_templates, list):
+        raise TypeError("proteinChain.templates must be a list.")
+    return explicit_templates
+
+
+def needs_template_search(input_json_data: Any) -> bool:
+    """Return whether any protein chain needs search template infrastructure."""
+    jobs = input_json_data if isinstance(input_json_data, list) else [input_json_data]
+
+    for infer_data in jobs:
+        if not isinstance(infer_data, Mapping):
+            continue
+        for sequence in infer_data.get("sequences", []):
+            if not isinstance(sequence, Mapping):
+                continue
+            protein_chain = sequence.get("proteinChain")
+            if not isinstance(protein_chain, Mapping):
+                continue
+            if "templates" not in protein_chain:
+                return True
+    return False

--- a/opendde/data/template/template_parser.py
+++ b/opendde/data/template/template_parser.py
@@ -329,6 +329,9 @@ class TemplateParser:
         chem_comps = TemplateParser._mmcif_loop_to_dict(
             "_chem_comp.", "_chem_comp.id", parsed_info
         )
+        entity_polys = TemplateParser._mmcif_loop_to_dict(
+            "_entity_poly.", "_entity_poly.entity_id", parsed_info
+        )
         struct_asyms = TemplateParser._mmcif_loop_to_list("_struct_asym.", parsed_info)
 
         entity_to_mmcif_chains = collections.defaultdict(list)
@@ -339,8 +342,11 @@ class TemplateParser:
 
         valid_chains = {}
         for entity_id, seq_info in polymers.items():
+            entity_poly_type = (
+                entity_polys.get(entity_id, {}).get("_entity_poly.type", "").lower()
+            )
             # Check if any component is peptide-like.
-            is_protein = any(
+            is_protein = entity_poly_type.strip().startswith("polypeptide(") or any(
                 "peptide" in chem_comps.get(m.id, {}).get("_chem_comp.type", "")
                 for m in seq_info
             )

--- a/opendde/data/template/template_utils.py
+++ b/opendde/data/template/template_utils.py
@@ -594,6 +594,7 @@ class TemplateHitProcessor:
         query_seq: str,
         chain_id: str,
         _zero_center: bool = True,
+        minimum_atom_count: int = 5,
     ) -> Tuple[Dict[str, Any], Optional[str]]:
         """Generates features for a template hit."""
         if not mmcif_obj or not mmcif_obj.chain_to_seqres:
@@ -618,7 +619,7 @@ class TemplateHitProcessor:
                 out_mask[q_idx] = all_mask[t_idx]
                 out_seq[q_idx] = template_seq[t_idx]
 
-        if np.sum(out_mask) < 5:
+        if np.sum(out_mask) < minimum_atom_count:
             raise TemplateAtomMaskAllZerosError(
                 f"Empty atom mask for {pdb_id}_{chain_id}"
             )

--- a/runner/batch_inference.py
+++ b/runner/batch_inference.py
@@ -24,7 +24,6 @@ from opendde.config.schema import (
 )
 from opendde.data.inference.json_maker import cif_to_input_json
 from opendde.data.inference.json_parser import lig_file_to_atom_info
-from opendde.data.tools import kalign
 from opendde.data.utils import pdb_to_cif
 from opendde.distributed.foldcp.config import FoldCPConfig
 from opendde.utils.logger import get_logger
@@ -285,6 +284,7 @@ def get_default_runner(
     foldcp_size_cp: int = 1,
     foldcp_devices: str = "",
     foldcp_metrics_jsonl: str = "",
+    input_json_paths: Optional[List[str]] = None,
     *,
     device: InferenceDevice = "auto",
 ) -> InferenceRunner:
@@ -317,6 +317,7 @@ def get_default_runner(
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
+        input_json_paths (Optional[List[str]]): Input JSON files.
 
     Returns:
         InferenceRunner: An instance of InferenceRunner.
@@ -360,12 +361,14 @@ def get_default_runner(
     configs.need_atom_confidence = need_atom_confidence
     configs.sample_diffusion.guidance["enable"] = use_tfg_guidance
 
-    if kalign_binary_path is not None or use_template:
-        configs.data.template.kalign_binary_path = kalign.resolve_kalign_binary(
-            kalign_binary_path
-        )
+    if kalign_binary_path is not None:
+        configs.data.template.kalign_binary_path = kalign_binary_path
 
-    runner = InferenceRunner(configs, foldcp_config=foldcp_config)
+    runner = InferenceRunner(
+        configs,
+        foldcp_config=foldcp_config,
+        input_json_paths=input_json_paths,
+    )
     configs = runner.configs
     logger.info(
         f"Inference by OpenDDE: model_name: {model_name}, dtype: {configs.dtype}"
@@ -517,6 +520,7 @@ def inference_jsons(
         foldcp_size_cp=foldcp_size_cp,
         foldcp_devices=foldcp_devices,
         foldcp_metrics_jsonl=foldcp_metrics_jsonl,
+        input_json_paths=infer_jsons,
     )
     try:
         configs = runner.configs
@@ -644,7 +648,7 @@ def inference_jsons(
     "--use_template",
     type=bool,
     default=False,
-    help="Use templates (requires templatesPath in input JSON).",
+    help="Use explicit, search-hit, or automatically searched templates.",
 )
 @click.option(
     "--use_rna_msa",
@@ -890,11 +894,8 @@ def predict(
         )
         logger.info("=" * 50)
         logger.info(
-            "Using templates for inference. Template files should have "
-            ".hhr or .a3m extensions and be specified in the JSON file.\n"
-            "Example: /path/to/template.hhr or /path/to/template.a3m\n"
-            "Note: Inference will proceed with automatic template search "
-            "if none are provided and use_template is True."
+            "Using proteinChain.templates, templatesPath, or automatic "
+            "template search for inference."
         )
         logger.info("=" * 50)
 

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -6,8 +6,9 @@ import os
 import random
 import time
 import traceback
-from collections.abc import Mapping, Sized
+from collections.abc import Mapping, Sequence, Sized
 from contextlib import nullcontext
+from copy import copy
 from datetime import timedelta
 from os.path import exists as opexists
 from os.path import join as opjoin
@@ -23,6 +24,8 @@ from opendde.config.inference import (
 )
 from opendde.config.schema import OpenDDEConfig
 from opendde.data.inference.infer_dataloader import get_inference_dataloader
+from opendde.data.template.template_input import needs_template_search
+from opendde.data.tools import kalign
 from opendde.distributed.foldcp.config import (
     FOLDCP_ENVIRONMENT_KEYS,
     FoldCPConfig,
@@ -99,6 +102,40 @@ def _download_inference_assets(configs: OpenDDEConfig) -> None:
         raise error
 
 
+def _prepare_template_dependencies(
+    configs: OpenDDEConfig,
+    input_json_paths: Sequence[str] | None,
+) -> None:
+    """Prepare only the template dependencies required by the inputs."""
+    paths = tuple(input_json_paths or ())
+    if not paths:
+        input_json_path = getattr(configs, "input_json_path", None)
+        paths = (str(input_json_path),) if input_json_path else ()
+
+    needs_search = bool(getattr(configs, "use_template", False))
+    if needs_search and paths:
+        try:
+            needs_search = False
+            for path in paths:
+                with open(path, encoding="utf-8") as file:
+                    if needs_template_search(json.load(file)):
+                        needs_search = True
+                        break
+        except Exception:
+            needs_search = True
+
+    if needs_search:
+        configs.data.template.kalign_binary_path = kalign.resolve_kalign_binary(
+            configs.data.template.kalign_binary_path
+        )
+
+    asset_configs = configs
+    if bool(getattr(configs, "use_template", False)) and not needs_search:
+        asset_configs = copy(configs)
+        asset_configs.use_template = False
+    _download_inference_assets(asset_configs)
+
+
 class InferenceRunner(object):
     """
     Runner class for AlphaFold3 model inference.
@@ -107,6 +144,8 @@ class InferenceRunner(object):
     Args:
         configs (OpenDDEConfig): Configuration object for inference.
         foldcp_config (FoldCPConfig | None): Pre-validated Fold-CP settings.
+        input_json_paths (Sequence[str] | None): Inputs used to determine whether
+            template search dependencies are required.
     """
 
     def __init__(
@@ -114,6 +153,7 @@ class InferenceRunner(object):
         configs: OpenDDEConfig,
         *,
         foldcp_config: FoldCPConfig | None = None,
+        input_json_paths: Sequence[str] | None = None,
     ) -> None:
         self._owns_process_group = False
         self._foldcp_environment_before_publish: dict[str, str | None] | None = None
@@ -129,7 +169,7 @@ class InferenceRunner(object):
                 rank=DIST_WRAPPER.rank,
             )
             self.init_env()
-            _download_inference_assets(self.configs)
+            _prepare_template_dependencies(self.configs, input_json_paths)
             self.init_basics()
             with skip_random_init() if self.configs.load_strict else nullcontext():
                 self.init_model()

--- a/runner/template_search.py
+++ b/runner/template_search.py
@@ -169,6 +169,8 @@ def update_template_info(
         for sequence in infer_data["sequences"]:
             if "proteinChain" in sequence:
                 protein_chain = sequence["proteinChain"]
+                if "templates" in protein_chain:
+                    continue
                 # Skip if templatesPath already exists and is valid
                 if "templatesPath" in protein_chain and os.path.exists(
                     protein_chain["templatesPath"]

--- a/tests/test_explicit_template_inputs.py
+++ b/tests/test_explicit_template_inputs.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from biotite.structure import AtomArray
+
+import opendde.data.template.template_featurizer as template_featurizer
+from opendde.data.constants import ATOM37_NUM
+from opendde.data.template.template_featurizer import InferenceTemplateFeaturizer
+from opendde.data.template.template_input import (
+    get_explicit_templates,
+    needs_template_search,
+)
+from opendde.data.template.template_parser import (
+    TemplateAtomMaskAllZerosError,
+    TemplateParser,
+)
+from opendde.data.template.template_utils import TemplateHitProcessor
+
+
+QUERY_SEQUENCE = "GHCIPTTSGPICLRD"
+MMCIF_FIXTURE = Path(__file__).parents[1] / "examples" / "2lwu.cif"
+EXAMPLE_INPUT = MMCIF_FIXTURE.parent / "example_explicit_template.json"
+
+
+def _template_entry(source, query_indices=None, template_indices=None):
+    if query_indices is None:
+        query_indices = list(range(len(QUERY_SEQUENCE)))
+    if template_indices is None:
+        template_indices = list(range(len(QUERY_SEQUENCE)))
+    return {
+        "mmcifPath": str(source),
+        "queryIndices": query_indices,
+        "templateIndices": template_indices,
+    }
+
+
+def _atom_array_for_sequences(*sequences):
+    lengths = [len(sequence) for sequence in sequences]
+    asym_ids = np.concatenate(
+        [np.full(length, asym_id) for asym_id, length in enumerate(lengths)]
+    )
+    atom_array = AtomArray(int(sum(lengths)))
+    atom_array.set_annotation("asym_id_int", asym_ids)
+    atom_array.set_annotation(
+        "res_id", np.concatenate([np.arange(1, length + 1) for length in lengths])
+    )
+    atom_array.set_annotation(
+        "chain_id",
+        np.concatenate(
+            [
+                np.full(length, chr(ord("A") + asym_id))
+                for asym_id, length in enumerate(lengths)
+            ]
+        ),
+    )
+    atom_array.set_annotation(
+        "centre_atom_mask", np.ones(len(atom_array), dtype=np.int8)
+    )
+    return atom_array
+
+
+def _protein_bioassembly(*, sequence=QUERY_SEQUENCE, count=1, **fields):
+    return [
+        {
+            "proteinChain": {
+                "sequence": sequence,
+                "count": count,
+                **fields,
+            }
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("protein_chain", "expected"),
+    [
+        ({"sequence": "ACDE", "count": 1}, None),
+        (
+            {"sequence": "ACDE", "count": 1, "templatesPath": "hits.a3m"},
+            None,
+        ),
+        ({"sequence": "ACDE", "count": 1, "templates": []}, []),
+        (
+            {
+                "sequence": "ACDE",
+                "count": 1,
+                "templates": [
+                    {
+                        "mmcif": "data_demo\n#\n",
+                        "queryIndices": [0],
+                        "templateIndices": [0],
+                    }
+                ],
+            },
+            [
+                {
+                    "mmcif": "data_demo\n#\n",
+                    "queryIndices": [0],
+                    "templateIndices": [0],
+                }
+            ],
+        ),
+    ],
+)
+def test_get_explicit_templates(protein_chain, expected):
+    assert get_explicit_templates(protein_chain) == expected
+
+
+def test_template_input_rejects_explicit_and_search_hit_modes_together():
+    with pytest.raises(ValueError, match="either explicit templates or templatesPath"):
+        get_explicit_templates({"templates": [], "templatesPath": "hits.a3m"})
+
+
+def test_template_input_rejects_null_explicit_templates():
+    with pytest.raises(TypeError, match="templates must be a list"):
+        get_explicit_templates({"templates": None})
+
+
+def test_needs_template_search_preserves_mixed_chain_modes():
+    mixed = [
+        {
+            "sequences": [
+                {"proteinChain": {"sequence": "AAAAA", "count": 1}},
+                {
+                    "proteinChain": {
+                        "sequence": "CCCCC",
+                        "count": 1,
+                        "templates": [],
+                    }
+                },
+            ]
+        }
+    ]
+    explicit_only = [
+        {
+            "sequences": [
+                {
+                    "proteinChain": {
+                        "sequence": "DDDDD",
+                        "count": 1,
+                        "templates": [
+                            {
+                                "mmcif": "data_demo\n#\n",
+                                "queryIndices": [0],
+                                "templateIndices": [0],
+                            }
+                        ],
+                    }
+                },
+            ]
+        }
+    ]
+
+    assert needs_template_search(mixed)
+    assert not needs_template_search(explicit_only)
+
+
+@pytest.mark.parametrize("raw_templates", ["not-a-list", [42]])
+def test_explicit_template_rejects_invalid_container_or_entry(raw_templates):
+    with pytest.raises(TypeError, match="must be a list|must be an object"):
+        InferenceTemplateFeaturizer._build_explicit_template_features(
+            query_seq=QUERY_SEQUENCE,
+            raw_templates=raw_templates,
+            json_path=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("template_info", "error"),
+    [
+        ({}, "requires either mmcif or mmcifPath"),
+        (
+            {"mmcif": "data_demo\n#\n", "mmcifPath": "demo.cif"},
+            "accepts only one of mmcif or mmcifPath",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [],
+                "templateIndices": [],
+            },
+            "non-empty",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [0],
+                "templateIndices": [0, 1],
+            },
+            "same length",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [True],
+                "templateIndices": [0],
+            },
+            "JSON integers",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [0.0],
+                "templateIndices": [0],
+            },
+            "JSON integers",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [0, 0],
+                "templateIndices": [0, 1],
+            },
+            "queryIndices must be unique",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [-1],
+                "templateIndices": [0],
+            },
+            "non-negative",
+        ),
+        (
+            {
+                "mmcif": "data_demo\n#\n",
+                "queryIndices": [len(QUERY_SEQUENCE)],
+                "templateIndices": [0],
+            },
+            "queryIndices exceed",
+        ),
+    ],
+)
+def test_explicit_template_rejects_invalid_source_and_indices(template_info, error):
+    with pytest.raises((TypeError, ValueError), match=error):
+        InferenceTemplateFeaturizer._build_explicit_template_features(
+            query_seq=QUERY_SEQUENCE,
+            raw_templates=[template_info],
+            json_path=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mmcif_object", "template_indices", "error"),
+    [
+        (None, [0], "Failed to parse"),
+        (
+            SimpleNamespace(
+                chain_to_seqres={"A": "AC", "B": "DE"},
+                header={"release_date": "2024-01-01"},
+            ),
+            [0],
+            "exactly one protein chain",
+        ),
+        (
+            SimpleNamespace(chain_to_seqres={"A": "AC"}, header={}),
+            [0],
+            "missing .*revision_date",
+        ),
+        (
+            SimpleNamespace(
+                chain_to_seqres={"A": "AC"},
+                header={"release_date": "2024-01-01"},
+            ),
+            [2],
+            "templateIndices exceed",
+        ),
+    ],
+)
+def test_explicit_template_rejects_invalid_parsed_structure(
+    monkeypatch, mmcif_object, template_indices, error
+):
+    monkeypatch.setattr(
+        TemplateParser,
+        "parse",
+        lambda **_kwargs: SimpleNamespace(mmcif_object=mmcif_object),
+    )
+
+    with pytest.raises(ValueError, match=error):
+        InferenceTemplateFeaturizer._build_explicit_template_features(
+            query_seq="AC",
+            raw_templates=[
+                {
+                    "mmcif": "data_demo\n#\n",
+                    "queryIndices": [0],
+                    "templateIndices": template_indices,
+                }
+            ],
+            json_path=None,
+        )
+
+
+def test_runnable_example_maps_only_selected_query_residues():
+    payload = json.loads(EXAMPLE_INPUT.read_text(encoding="utf-8"))
+    query_indices = payload[0]["sequences"][0]["proteinChain"]["templates"][0][
+        "queryIndices"
+    ]
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=payload[0]["sequences"],
+        atom_array=_atom_array_for_sequences(QUERY_SEQUENCE),
+        use_template=True,
+        online_template_featurizer=None,
+        json_path=str(EXAMPLE_INPUT),
+    )
+
+    assert features["template_aatype"].shape == (4, 15)
+    residue_mask = features["template_atom_mask"][0].any(axis=-1)
+    assert residue_mask[query_indices].all()
+    unmapped = sorted(set(range(15)) - set(query_indices))
+    if unmapped:
+        assert not residue_mask[unmapped].any()
+    assert not features["template_atom_mask"][1:].any()
+
+
+def test_nonidentity_index_mapping_places_exact_template_residues_and_coordinates():
+    query_sequence = "A" * 18
+    query_indices = [16, 1, 6]
+    template_indices = [14, 7, 7]
+    processor = TemplateHitProcessor(mmcif_dir="")
+
+    features = InferenceTemplateFeaturizer._build_explicit_template_features(
+        query_seq=query_sequence,
+        raw_templates=[
+            _template_entry(
+                MMCIF_FIXTURE,
+                query_indices=query_indices,
+                template_indices=template_indices,
+            )
+        ],
+        json_path=None,
+    )[0]
+
+    parsed = TemplateParser.parse(
+        file_id="coordinate_reference",
+        mmcif_string=MMCIF_FIXTURE.read_text(encoding="utf-8"),
+    )
+    assert parsed.mmcif_object is not None
+    chain_id, template_sequence = next(
+        iter(parsed.mmcif_object.chain_to_seqres.items())
+    )
+    source_positions, source_mask = processor._get_atom_positions(
+        parsed.mmcif_object, chain_id, 150.0, _zero_center=True
+    )
+
+    expected_sequence = ["-"] * len(query_sequence)
+    for query_index, template_index in zip(query_indices, template_indices):
+        expected_sequence[query_index] = template_sequence[template_index]
+        np.testing.assert_array_equal(
+            features["template_all_atom_positions"][query_index],
+            source_positions[template_index],
+        )
+        np.testing.assert_array_equal(
+            features["template_all_atom_masks"][query_index],
+            source_mask[template_index],
+        )
+
+    assert features["template_sequence"] == "".join(expected_sequence).encode()
+    unmapped = sorted(set(range(len(query_sequence))) - set(query_indices))
+    assert not features["template_all_atom_masks"][unmapped].any()
+
+
+def test_explicit_mapping_accepts_one_nonzero_atom(monkeypatch):
+    positions = np.zeros((len(QUERY_SEQUENCE), ATOM37_NUM, 3), dtype=np.float32)
+    masks = np.zeros((len(QUERY_SEQUENCE), ATOM37_NUM), dtype=np.float32)
+    positions[0, 0] = [1.0, 2.0, 3.0]
+    masks[0, 0] = 1.0
+    monkeypatch.setattr(
+        TemplateHitProcessor,
+        "_get_atom_positions",
+        lambda *_args, **_kwargs: (positions, masks),
+    )
+
+    features = InferenceTemplateFeaturizer._build_explicit_template_features(
+        query_seq=QUERY_SEQUENCE,
+        raw_templates=[
+            _template_entry(
+                MMCIF_FIXTURE,
+                query_indices=[0],
+                template_indices=[0],
+            )
+        ],
+        json_path=None,
+    )[0]
+
+    assert features["template_all_atom_masks"].sum() == 1
+
+
+def test_legacy_hit_extraction_retains_five_atom_minimum(monkeypatch):
+    processor = TemplateHitProcessor(mmcif_dir="unused")
+    positions = np.zeros((1, ATOM37_NUM, 3), dtype=np.float32)
+    masks = np.zeros((1, ATOM37_NUM), dtype=np.float32)
+    masks[0, 0] = 1.0
+    monkeypatch.setattr(
+        processor,
+        "_get_atom_positions",
+        lambda *_args, **_kwargs: (positions, masks),
+    )
+
+    with pytest.raises(TemplateAtomMaskAllZerosError, match="Empty atom mask"):
+        processor._extract_template_features(
+            SimpleNamespace(chain_to_seqres={"A": "A"}),
+            "legacy",
+            {0: 0},
+            "A",
+            "A",
+            "A",
+        )
+
+
+def test_explicit_template_rejects_all_zero_selected_atom_mask(monkeypatch):
+    monkeypatch.setattr(
+        TemplateHitProcessor,
+        "_get_atom_positions",
+        lambda *_args, **_kwargs: (
+            np.zeros((len(QUERY_SEQUENCE), ATOM37_NUM, 3), dtype=np.float32),
+            np.zeros((len(QUERY_SEQUENCE), ATOM37_NUM), dtype=np.float32),
+        ),
+    )
+
+    with pytest.raises(TemplateAtomMaskAllZerosError, match="Empty atom mask"):
+        InferenceTemplateFeaturizer._build_explicit_template_features(
+            query_seq=QUERY_SEQUENCE,
+            raw_templates=[
+                _template_entry(
+                    MMCIF_FIXTURE,
+                    query_indices=[0],
+                    template_indices=[0],
+                )
+            ],
+            json_path=None,
+        )
+
+
+def test_explicit_templates_keep_input_order_and_do_not_parse_after_four():
+    entries = [
+        _template_entry(
+            MMCIF_FIXTURE,
+            query_indices=[index],
+            template_indices=[index],
+        )
+        for index in range(1, 5)
+    ]
+    entries.append(
+        _template_entry(
+            Path("unused-missing-template.cif"),
+            query_indices=[5],
+            template_indices=[5],
+        )
+    )
+
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=_protein_bioassembly(templates=entries),
+        atom_array=_atom_array_for_sequences(QUERY_SEQUENCE),
+        use_template=True,
+        online_template_featurizer=None,
+    )
+
+    assert features["template_atom_mask"].shape[0] == 4
+    for template_index, query_index in enumerate(range(1, 5)):
+        residue_mask = features["template_atom_mask"][template_index].any(axis=-1)
+        assert residue_mask[query_index]
+        assert residue_mask.sum() == 1
+
+
+def test_inline_explicit_mmcif_uses_the_same_feature_path():
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=_protein_bioassembly(
+            templates=[
+                {
+                    "mmcif": MMCIF_FIXTURE.read_text(encoding="utf-8"),
+                    "queryIndices": list(range(15)),
+                    "templateIndices": list(range(15)),
+                }
+            ]
+        ),
+        atom_array=_atom_array_for_sequences(QUERY_SEQUENCE),
+        use_template=True,
+        online_template_featurizer=None,
+    )
+
+    assert features["template_atom_mask"][0].any()
+
+
+def test_global_template_disable_does_not_parse_explicit_entries(monkeypatch):
+    monkeypatch.setattr(
+        TemplateParser,
+        "parse",
+        lambda **_kwargs: pytest.fail("templates must not be parsed when disabled"),
+    )
+
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=_protein_bioassembly(
+            sequence="ACDEF", templates=[{"invalid": "ignored"}]
+        ),
+        atom_array=_atom_array_for_sequences("ACDEF"),
+        use_template=False,
+        online_template_featurizer=None,
+    )
+
+    assert not features["template_atom_mask"].any()
+
+
+def test_explicit_template_missing_path_fails_closed(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        InferenceTemplateFeaturizer._load_explicit_template_mmcif(
+            {"mmcifPath": "missing.cif"},
+            json_path=str(tmp_path / "input.json"),
+            template_index=0,
+        )
+
+
+def test_explicit_template_list_is_copied_to_each_chain_count():
+    atom_array = _atom_array_for_sequences(QUERY_SEQUENCE, QUERY_SEQUENCE)
+
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=_protein_bioassembly(
+            count=2, templates=[_template_entry(MMCIF_FIXTURE)]
+        ),
+        atom_array=atom_array,
+        use_template=True,
+        online_template_featurizer=None,
+    )
+
+    first = features["template_atom_mask"][0, :15]
+    second = features["template_atom_mask"][0, 15:]
+    assert first.any()
+    assert np.array_equal(first, second)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "parser_name"),
+    [(".a3m", "HmmsearchA3MParser"), (".hhr", "HHRParser")],
+)
+def test_legacy_search_hit_path_still_uses_existing_featurizer(
+    tmp_path, monkeypatch, suffix, parser_name
+):
+    hit_path = tmp_path / f"hits{suffix}"
+    hit_path.write_text(">query\nACDEF\n", encoding="utf-8")
+    captured = []
+
+    class _SearchFeaturizer:
+        def get_templates(self, **kwargs):
+            captured.append(kwargs)
+            return SimpleNamespace(features=[]), {}
+
+    monkeypatch.setattr(
+        getattr(template_featurizer, parser_name), "parse", lambda **_kwargs: []
+    )
+
+    features = InferenceTemplateFeaturizer.make_template_feature(
+        bioassembly=_protein_bioassembly(sequence="ACDEF", templatesPath=str(hit_path)),
+        atom_array=_atom_array_for_sequences("ACDEF"),
+        use_template=True,
+        online_template_featurizer=_SearchFeaturizer(),
+    )
+
+    assert len(captured) == 1
+    assert features["template_aatype"].shape == (4, 5)

--- a/tests/test_explicit_template_runtime.py
+++ b/tests/test_explicit_template_runtime.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+import json
+from types import SimpleNamespace
+
+import pytest
+from ml_collections.config_dict import ConfigDict
+
+from opendde.config.inference import build_inference_config
+from opendde.data.inference import infer_dataloader
+from runner import batch_inference, inference, template_search
+
+
+def _protein_chain(template_mode, tmp_path):
+    chain = {"sequence": "ACDEFG", "count": 1}
+    if template_mode == "explicit":
+        chain["templates"] = [
+            {
+                "mmcif": "data_template\n#\n",
+                "queryIndices": [0],
+                "templateIndices": [0],
+            }
+        ]
+    elif template_mode == "disabled":
+        chain["templates"] = []
+    elif template_mode == "search_hits":
+        hit_path = tmp_path / "hits.a3m"
+        hit_path.write_text(">query\nACDEFG\n", encoding="utf-8")
+        chain["templatesPath"] = str(hit_path)
+    return chain
+
+
+def _write_input(tmp_path, template_mode):
+    input_path = tmp_path / f"{template_mode}.json"
+    input_path.write_text(
+        json.dumps(
+            [
+                {
+                    "name": template_mode,
+                    "sequences": [
+                        {"proteinChain": _protein_chain(template_mode, tmp_path)}
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return input_path
+
+
+def _dataset_configs(tmp_path, template_mode):
+    input_path = _write_input(tmp_path, template_mode)
+    template_dir = tmp_path / "mmcif"
+    if template_mode in {"auto", "search_hits"}:
+        template_dir.mkdir()
+
+    configs = ConfigDict()
+    configs.input_json_path = str(input_path)
+    configs.dump_dir = str(tmp_path / "output")
+    configs.use_msa = False
+    configs.use_rna_msa = False
+    configs.use_template = True
+    configs.data = ConfigDict()
+    configs.data.ccd_components_file = str(tmp_path / "components.cif")
+    configs.data.ccd_components_rdkit_mol_file = str(tmp_path / "components.pkl")
+    configs.data.template = ConfigDict()
+    configs.data.template.prot_template_mmcif_dir = str(template_dir)
+    configs.data.template.prot_template_cache_dir = str(tmp_path / "template-cache")
+    configs.data.template.kalign_binary_path = "kalign"
+    configs.data.template.release_dates_path = ""
+    configs.data.template.obsolete_pdbs_path = ""
+    configs.data.template.fetch_remote = False
+    return configs, template_dir
+
+
+@pytest.mark.parametrize(
+    ("template_mode", "expects_search"),
+    [
+        ("explicit", False),
+        ("auto", True),
+    ],
+)
+def test_dataset_constructs_search_processor_only_when_needed(
+    tmp_path, monkeypatch, template_mode, expects_search
+):
+    configs, template_dir = _dataset_configs(tmp_path, template_mode)
+    search_processor = object()
+    monkeypatch.setattr(
+        infer_dataloader,
+        "TemplateHitFeaturizer",
+        lambda **_kwargs: search_processor,
+    )
+
+    dataset = infer_dataloader.InferenceDataset(configs)
+
+    assert (dataset.online_template_featurizer is search_processor) is expects_search
+    if not expects_search:
+        assert not template_dir.exists()
+
+
+def test_template_preprocessing_skips_explicit_and_disabled_but_regenerates_missing_hit(
+    tmp_path, monkeypatch
+):
+    msa_dir = tmp_path / "msa"
+    msa_dir.mkdir()
+    paired_path = msa_dir / "pairing.a3m"
+    paired_path.write_text(">query\nACDEFG\n", encoding="utf-8")
+    existing_hits = tmp_path / "existing-hits.a3m"
+    existing_hits.write_text(">query\nACDEFG\n", encoding="utf-8")
+    searches = []
+
+    def run_search(**kwargs):
+        searches.append(kwargs)
+        (msa_dir / "hmmsearch.a3m").write_text(">query\nACDEFG\n", encoding="utf-8")
+
+    monkeypatch.setattr(template_search, "run_template_search", run_search)
+    explicit_templates = [
+        {
+            "mmcif": "data_template\n#\n",
+            "queryIndices": [0],
+            "templateIndices": [0],
+        }
+    ]
+    payload = [
+        {
+            "name": "mixed",
+            "sequences": [
+                {
+                    "proteinChain": {
+                        "sequence": "ACDEFG",
+                        "count": 1,
+                        "pairedMsaPath": str(paired_path),
+                        "templates": explicit_templates,
+                    }
+                },
+                {
+                    "proteinChain": {
+                        "sequence": "ACDEFG",
+                        "count": 1,
+                        "pairedMsaPath": str(paired_path),
+                        "templates": [],
+                    }
+                },
+                {
+                    "proteinChain": {
+                        "sequence": "ACDEFG",
+                        "count": 1,
+                        "pairedMsaPath": str(paired_path),
+                        "templatesPath": str(tmp_path / "missing-hits.a3m"),
+                    }
+                },
+                {
+                    "proteinChain": {
+                        "sequence": "ACDEFG",
+                        "count": 1,
+                        "pairedMsaPath": str(paired_path),
+                        "templatesPath": str(existing_hits),
+                    }
+                },
+            ],
+        }
+    ]
+
+    assert template_search.update_template_info(payload)
+
+    explicit, disabled, missing_hit, existing_hit = [
+        item["proteinChain"] for item in payload[0]["sequences"]
+    ]
+    assert explicit["templates"] == explicit_templates
+    assert "templatesPath" not in explicit
+    assert disabled["templates"] == []
+    assert "templatesPath" not in disabled
+    assert missing_hit["templatesPath"] == str(msa_dir / "hmmsearch.a3m")
+    assert existing_hit["templatesPath"] == str(existing_hits)
+    assert len(searches) == 1
+
+
+def _patch_runner_startup(monkeypatch, metadata_requests):
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+        ),
+    )
+    monkeypatch.setattr(
+        inference, "FoldCPBenchmarkRecorder", lambda *_args, **_kwargs: object()
+    )
+    monkeypatch.setattr(inference.InferenceRunner, "init_env", lambda self: None)
+    for method_name in ("init_basics", "init_model", "load_checkpoint"):
+        monkeypatch.setattr(
+            inference.InferenceRunner,
+            method_name,
+            lambda self: None,
+        )
+    monkeypatch.setattr(
+        inference.InferenceRunner,
+        "init_dumper",
+        lambda self, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        inference,
+        "_download_inference_assets",
+        lambda configs: metadata_requests.append(configs.use_template),
+    )
+
+
+@pytest.mark.parametrize(
+    ("template_mode", "needs_search"),
+    [
+        ("explicit", False),
+        ("auto", True),
+    ],
+)
+def test_public_batch_boundary_gates_actual_kalign_resolver_and_search_metadata(
+    tmp_path, monkeypatch, template_mode, needs_search
+):
+    input_path = _write_input(tmp_path, template_mode)
+    metadata_requests = []
+    kalign_requests = []
+    _patch_runner_startup(monkeypatch, metadata_requests)
+    monkeypatch.setattr(
+        inference.kalign,
+        "resolve_kalign_binary",
+        lambda path: kalign_requests.append(path) or "/resolved/kalign",
+    )
+    monkeypatch.setattr(
+        batch_inference, "preprocess_input", lambda path, **_kwargs: path
+    )
+    monkeypatch.setattr(batch_inference, "infer_predict", lambda *_args: None)
+
+    batch_inference.inference_jsons(
+        str(input_path),
+        use_msa=False,
+        use_template=True,
+        kalign_binary_path="configured-kalign",
+        device="cpu",
+    )
+
+    assert kalign_requests == (["configured-kalign"] if needs_search else [])
+    assert metadata_requests == [needs_search]
+
+
+def test_asset_preparation_handles_direct_mixed_and_unreadable_inputs(
+    tmp_path, monkeypatch
+):
+    downloads = []
+    kalign_requests = []
+    configs = build_inference_config(fill_required_with_null=True)
+    configs.use_template = True
+    explicit_path = _write_input(tmp_path, "disabled")
+    automatic_path = _write_input(tmp_path, "auto")
+    configs.input_json_path = str(explicit_path)
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "download_inference_cache",
+        lambda asset_configs: downloads.append(asset_configs.use_template),
+    )
+    monkeypatch.setattr(
+        inference.kalign,
+        "resolve_kalign_binary",
+        lambda path: kalign_requests.append(path) or "/resolved/kalign",
+    )
+
+    inference._prepare_template_dependencies(configs, None)
+    inference._prepare_template_dependencies(
+        configs, [str(explicit_path), str(automatic_path)]
+    )
+    inference._prepare_template_dependencies(configs, [str(tmp_path / "missing.json")])
+
+    assert downloads == [False, True, True]
+    assert len(kalign_requests) == 2
+    assert configs.use_template is True

--- a/tests/test_inference_config.py
+++ b/tests/test_inference_config.py
@@ -86,7 +86,7 @@ def test_get_default_runner_config_build_does_not_mutate_base_defaults(monkeypat
     from runner import batch_inference
 
     class DummyRunner:
-        def __init__(self, cfg, *, foldcp_config=None):
+        def __init__(self, cfg, *, foldcp_config=None, input_json_paths=None):
             self.configs = cfg
             self.foldcp_config = foldcp_config
 
@@ -272,7 +272,7 @@ def test_get_default_runner_passes_foldcp_config_once(monkeypatch):
     captured = {}
 
     class DummyRunner:
-        def __init__(self, cfg, *, foldcp_config=None):
+        def __init__(self, cfg, *, foldcp_config=None, input_json_paths=None):
             captured["foldcp"] = foldcp_config
             self.configs = cfg
             self.foldcp_config = foldcp_config
@@ -303,29 +303,21 @@ def test_foldcp_config_validation_is_independent_of_process_environment(monkeypa
     assert FoldCPConfig().validate().mode == "single"
 
 
-def test_get_default_runner_uses_shared_kalign_resolver(monkeypatch):
+def test_get_default_runner_preserves_kalign_path_for_runner(monkeypatch):
     from runner import batch_inference
 
-    calls = []
-
     class DummyRunner:
-        def __init__(self, cfg, *, foldcp_config=None):
+        def __init__(self, cfg, *, foldcp_config=None, input_json_paths=None):
             self.configs = cfg
 
     monkeypatch.setattr(batch_inference, "InferenceRunner", DummyRunner)
-    monkeypatch.setattr(
-        batch_inference.kalign,
-        "resolve_kalign_binary",
-        lambda binary_path: calls.append(binary_path) or "/tools/kalign",
-    )
 
     runner = batch_inference.get_default_runner(
         use_template=True,
         kalign_binary_path="custom-kalign",
     )
 
-    assert calls == ["custom-kalign"]
-    assert runner.configs.data.template.kalign_binary_path == "/tools/kalign"
+    assert runner.configs.data.template.kalign_binary_path == "custom-kalign"
 
 
 def test_download_inference_assets_single_process_downloads_directly(monkeypatch):

--- a/tests/test_template_parser_protein_polymer.py
+++ b/tests/test_template_parser_protein_polymer.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+import pytest
+
+from opendde.data.template.template_parser import TemplateParser
+
+
+def _polymer_data(polymer_type):
+    return {
+        "_entity_poly_seq.entity_id": ["1"],
+        "_entity_poly_seq.mon_id": ["ALA"],
+        "_entity_poly_seq.num": ["1"],
+        "_chem_comp.id": ["ALA"],
+        "_chem_comp.type": ["."],
+        "_entity_poly.entity_id": ["1"],
+        "_entity_poly.type": [polymer_type],
+        "_struct_asym.id": ["A"],
+        "_struct_asym.entity_id": ["1"],
+    }
+
+
+@pytest.mark.parametrize("polymer_type", ["polypeptide(L)", "polypeptide(D)"])
+def test_parser_uses_entity_poly_type_when_component_types_are_unknown(polymer_type):
+    chains = TemplateParser._get_protein_chains(_polymer_data(polymer_type))
+
+    assert list(chains) == ["A"]
+    assert chains["A"][0].id == "ALA"
+
+
+@pytest.mark.parametrize(
+    "polymer_type", ["peptide nucleic acid", "cyclic-pseudo-peptide"]
+)
+def test_parser_rejects_non_polypeptide_entity_types(polymer_type):
+    assert TemplateParser._get_protein_chains(_polymer_data(polymer_type)) == {}


### PR DESCRIPTION
## Summary

- Add chain-local explicit mmCIF templates using paired, zero-based
  `queryIndices` and `templateIndices`.
- Support inline `mmcif` and JSON-relative `mmcifPath` sources.
- Preserve automatic search and existing `templatesPath` behavior.
- Allow `templates: []` to disable templates for an individual chain.
- Skip Kalign and template-search assets when every chain is explicit or
  disabled.

## Validation

- Full test suite passed on Python 3.11, 3.12, and 3.13.
- Network template tests passed.
- Wheel build, fresh installation, CLI, and sparse-template smoke passed.
- Four-rank Fold-CP inference completed using the documented example.
