### PR TITLE
Batch independent inference seeds per GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ User-facing changes to OpenDDE are documented here.
 
 ## [Unreleased]
 
-No changes yet.
+### Added
+
+- Added single-node seed-parallel `D x 1` inference using the existing Fold-CP
+  topology flags, while preserving serial and `1 x P` Fold-CP behavior and
+  rejecting hybrid `D > 1, P > 1` launches.
 
 ## [1.1.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ User-facing changes to OpenDDE are documented here.
 
 ### Added
 
-- Added single-node seed-parallel `D x 1` inference using the existing Fold-CP
-  topology flags, while preserving serial and `1 x P` Fold-CP behavior and
-  rejecting hybrid `D > 1, P > 1` launches.
+- Added `--seed_batch_size` for tensor-batched independent seeds on one GPU.
+  The same rank-local batching path composes with single-node `D x 1` seed
+  sharding; `1 x P` Fold-CP remains available with seed batch size 1.
 
 ## [1.1.0] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -209,24 +209,38 @@ For production runs, enable the preprocessing features you need, for example
 require network access, HMMER/Kalign binaries, and large local search databases;
 see the inference guide for details.
 
-## Multi-GPU Seed-Parallel Inference
+## Seed-Batched Inference
 
-Independent seeds can run concurrently on separate GPUs with the existing
-topology flags. `D=4, P=1` uses the normal single-card model path on four seed
-lanes:
+Independent seeds can share one model call on a GPU. `--seed_batch_size`
+defaults to `1`; set it to the maximum number of seeds to run together:
+
+```bash
+opendde pred \
+  -i input.json -o output_b2 -n opendde_v1 \
+  --seeds 101,102 \
+  --seed_batch_size 2
+```
+
+The same rank-local batching path works with multi-GPU seed sharding. `D=4`,
+`P=1`, and `B=2` assign seeds by rank first, then batch up to two seeds per GPU:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node 4 \
   -m runner.batch_inference pred \
-  -i input.json -o output_dp4 -n opendde_v1 \
-  --seeds 101,102,103,104 \
+  -i input.json -o output_d4_b2 -n opendde_v1 \
+  --seeds 101,102,103,104,105,106,107,108 \
+  --seed_batch_size 2 \
   --foldcp_mode single \
   --foldcp_size_dp 4 \
   --foldcp_size_cp 1
 ```
 
-Seed-parallel seeds must be unique, and their count must be at least `D`. Each
-seed is assigned to one rank and written once under the normal output layout.
+Rank `r` receives `seeds[r::D]`, then runs ordered chunks of at most `B`; a
+smaller final chunk is allowed. Seeds must be unique when `D>1` or `B>1`, and
+multi-rank runs need at least `D` seeds. Seed batching requires `P=1`,
+`num_workers=0`, `model.N_model_seed=1`, and Training-Free Guidance disabled.
+OpenDDE does not automatically reduce `B` or retry after OOM.
+Each seed is still written once under the normal output layout.
 
 ## Multi-GPU Fold-CP Inference
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,25 @@ For production runs, enable the preprocessing features you need, for example
 require network access, HMMER/Kalign binaries, and large local search databases;
 see the inference guide for details.
 
+## Multi-GPU Seed-Parallel Inference
+
+Independent seeds can run concurrently on separate GPUs with the existing
+topology flags. `D=4, P=1` uses the normal single-card model path on four seed
+lanes:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node 4 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_dp4 -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --foldcp_mode single \
+  --foldcp_size_dp 4 \
+  --foldcp_size_cp 1
+```
+
+Seed-parallel seeds must be unique, and their count must be at least `D`. Each
+seed is assigned to one rank and written once under the normal output layout.
+
 ## Multi-GPU Fold-CP Inference
 
 > [!IMPORTANT]

--- a/docs/foldcp_e2e_baseline.md
+++ b/docs/foldcp_e2e_baseline.md
@@ -7,11 +7,26 @@ environment, and raw measurements from the same run.
 
 ## Execution requirements
 
-- `P=1` uses normal single-process inference.
-- Multi-GPU inference uses a `1 x P` topology with
+Let `D=--foldcp_size_dp` and `P=--foldcp_size_cp`:
+
+| Mode | `foldcp_mode` | `D` | `P` | Required world size |
+| --- | --- | ---: | ---: | ---: |
+| Serial | `single` | 1 | 1 | 1 |
+| Seed parallel | `single` | >1 | 1 | `D` |
+| Fold-CP | `distributed` | 1 | >1 | `P` |
+| Hybrid | - | >1 | >1 | Rejected |
+
+- `D=1, P=1` uses normal single-process inference.
+- Seed parallelism uses the normal single-card model independently on each of
+  `D` ranks. Seeds must be unique and their count must be at least `D`.
+- Fold-CP uses a `1 x P` topology with
   `--foldcp_size_dp 1 --foldcp_size_cp P`, where `P > 1`.
 - `--nproc_per_node` must equal
   `--foldcp_size_dp * --foldcp_size_cp`.
+- Hybrid `D>1, P>1` and mismatched-world-size launches are rejected before
+  model loading.
+- Multi-GPU inference is single-node and requires a shared input/output
+  filesystem.
 - Multi-GPU Fold-CP uses
   `--trimul_kernel torch --triatt_kernel torch`; cuEquivariance triangle
   kernels are not supported in this mode.
@@ -32,11 +47,30 @@ CUDA_VISIBLE_DEVICES=0 \
 CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 python -m runner.batch_inference pred \
   -i input.json -o output_p1 -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --sample 1 --step 2 --cycle 1 --dtype bf16 \
+  --use_msa true --use_template false --use_rna_msa false \
+  --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
+  --deterministic true
+```
+
+To run those seeds independently on four GPUs, use `D=4, P=1`:
+
+```bash
+D=4
+GPU_LIST="$(seq -s, 0 $((D - 1)))"
+
+CUDA_VISIBLE_DEVICES="$GPU_LIST" \
+CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+torchrun --standalone --nproc_per_node "$D" \
+  -m runner.batch_inference pred \
+  -i input.json -o "output_d${D}" -n opendde_v1 \
+  --seeds 101,102,103,104 \
   --sample 1 --step 2 --cycle 1 --dtype bf16 \
   --use_msa true --use_template false --use_rna_msa false \
   --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
   --deterministic true \
-  --foldcp_mode single --foldcp_size_cp 1
+  --foldcp_mode single --foldcp_size_dp "$D" --foldcp_size_cp 1
 ```
 
 For `P>1`, launch one process per GPU. This example uses four GPUs; replace
@@ -51,6 +85,7 @@ CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 torchrun --standalone --nproc_per_node "$P" \
   -m runner.batch_inference pred \
   -i input.json -o "output_p${P}" -n opendde_v1 \
+  --seeds 101,102,103,104 \
   --sample 1 --step 2 --cycle 1 --dtype bf16 \
   --use_msa true --use_template false --use_rna_msa false \
   --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
@@ -60,12 +95,33 @@ torchrun --standalone --nproc_per_node "$P" \
 
 The commands are a controlled comparison template, not a performance
 benchmark. Adjust the model settings for production, but keep every setting
-identical between the `P=1` reference and the `P>1` comparison.
+identical between the serial, `D>1`, and `P>1` comparisons.
+
+Validate the topology guards separately. Both commands must fail before model
+loading:
+
+```bash
+# Hybrid D=2, P=2.
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node 4 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_invalid_hybrid -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --foldcp_mode distributed --foldcp_size_dp 2 --foldcp_size_cp 2
+
+# WORLD_SIZE=2 does not match D=4, P=1.
+CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node 2 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_invalid_world -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
+```
 
 ## Validating numerical alignment
 
 - Use the same Git commit, checkpoint, input JSON, MSA/template features, seed,
   dtype, cycle count, diffusion steps, and kernel settings for every run.
+- For `D x 1`, verify that every requested `(job, seed)` directory exists
+  exactly once and no other seed directory was produced.
 - Verify output schemas, tensor shapes, atom ordering, and finite values before
   comparing numerical values.
 - Compare prediction coordinates and summary-confidence outputs with tolerances

--- a/docs/foldcp_e2e_baseline.md
+++ b/docs/foldcp_e2e_baseline.md
@@ -1,30 +1,42 @@
 # Fold-CP 1 x P Reproduction Guide
 
-This document describes how to run and validate arbitrary-`P` Fold-CP
-inference. It intentionally does not publish performance or capacity numbers:
-those claims require the exact source commit, input provenance, runtime
-environment, and raw measurements from the same run.
+This document describes how to run and validate seed-batched inference,
+multi-GPU seed sharding, and arbitrary-`P` Fold-CP. It intentionally does not
+publish performance or capacity numbers: those claims require the exact source
+commit, input provenance, runtime environment, and raw measurements from the
+same run.
 
 ## Execution requirements
 
-Let `D=--foldcp_size_dp` and `P=--foldcp_size_cp`:
+Let `D=--foldcp_size_dp`, `P=--foldcp_size_cp`, and
+`B=--seed_batch_size`:
 
-| Mode | `foldcp_mode` | `D` | `P` | Required world size |
-| --- | --- | ---: | ---: | ---: |
-| Serial | `single` | 1 | 1 | 1 |
-| Seed parallel | `single` | >1 | 1 | `D` |
-| Fold-CP | `distributed` | 1 | >1 | `P` |
-| Hybrid | - | >1 | >1 | Rejected |
+| Mode | `foldcp_mode` | `D` | `P` | `B` | Required world size |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Scalar single GPU | `single` | 1 | 1 | 1 | 1 |
+| Batched single GPU | `single` | 1 | 1 | >1 | 1 |
+| Sharded seed batches | `single` | >1 | 1 | >=1 | `D` |
+| Fold-CP | `distributed` | 1 | >1 | 1 | `P` |
+| Batched Fold-CP | - | any | >1 | >1 | Rejected |
+| Hybrid | - | >1 | >1 | any | Rejected |
 
-- `D=1, P=1` uses normal single-process inference.
-- Seed parallelism uses the normal single-card model independently on each of
-  `D` ranks. Seeds must be unique and their count must be at least `D`.
+- `D=1, P=1, B=1` uses scalar single-process inference.
+- `B>1` batches independent seeds on the leading model dimension and requires
+  `P=1` and `num_workers=0`.
+- Training-Free Guidance requires `B=1`; combining it with `B>1` is rejected.
+- Rank `r` receives `seeds[r::D]`, then partitions its ordered slice into
+  chunks of at most `B`; a smaller final chunk is valid. This is the same path
+  for `D=1` and `D>1`.
+- Seeds must be unique when `D>1` or `B>1`. Multi-rank runs require at least
+  `D` seeds.
 - Fold-CP uses a `1 x P` topology with
-  `--foldcp_size_dp 1 --foldcp_size_cp P`, where `P > 1`.
+  `--foldcp_size_dp 1 --foldcp_size_cp P --seed_batch_size 1`, where `P > 1`.
 - `--nproc_per_node` must equal
   `--foldcp_size_dp * --foldcp_size_cp`.
 - Hybrid `D>1, P>1` and mismatched-world-size launches are rejected before
   model loading.
+- OpenDDE does not automatically choose or reduce `B`, or retry serially after
+  an OOM.
 - Multi-GPU inference is single-node and requires a shared input/output
   filesystem.
 - Multi-GPU Fold-CP uses
@@ -48,13 +60,29 @@ CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 python -m runner.batch_inference pred \
   -i input.json -o output_p1 -n opendde_v1 \
   --seeds 101,102,103,104 \
+  --seed_batch_size 1 \
   --sample 1 --step 2 --cycle 1 --dtype bf16 \
   --use_msa true --use_template false --use_rna_msa false \
   --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
   --deterministic true
 ```
 
-To run those seeds independently on four GPUs, use `D=4, P=1`:
+Run the same four seeds two at a time on one GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 \
+CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+python -m runner.batch_inference pred \
+  -i input.json -o output_b2 -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --seed_batch_size 2 \
+  --sample 1 --step 2 --cycle 1 --dtype bf16 \
+  --use_msa true --use_template false --use_rna_msa false \
+  --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
+  --deterministic true
+```
+
+To run two seeds per GPU on four GPUs, use `D=4, P=1, B=2`:
 
 ```bash
 D=4
@@ -64,8 +92,9 @@ CUDA_VISIBLE_DEVICES="$GPU_LIST" \
 CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 torchrun --standalone --nproc_per_node "$D" \
   -m runner.batch_inference pred \
-  -i input.json -o "output_d${D}" -n opendde_v1 \
-  --seeds 101,102,103,104 \
+  -i input.json -o "output_d${D}_b2" -n opendde_v1 \
+  --seeds 101,102,103,104,105,106,107,108 \
+  --seed_batch_size 2 \
   --sample 1 --step 2 --cycle 1 --dtype bf16 \
   --use_msa true --use_template false --use_rna_msa false \
   --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
@@ -85,7 +114,8 @@ CUBLAS_WORKSPACE_CONFIG=:4096:8 \
 torchrun --standalone --nproc_per_node "$P" \
   -m runner.batch_inference pred \
   -i input.json -o "output_p${P}" -n opendde_v1 \
-  --seeds 101,102,103,104 \
+  --seeds 101 \
+  --seed_batch_size 1 \
   --sample 1 --step 2 --cycle 1 --dtype bf16 \
   --use_msa true --use_template false --use_rna_msa false \
   --trimul_kernel torch --triatt_kernel torch --enable_tf32 false \
@@ -95,9 +125,10 @@ torchrun --standalone --nproc_per_node "$P" \
 
 The commands are a controlled comparison template, not a performance
 benchmark. Adjust the model settings for production, but keep every setting
-identical between the serial, `D>1`, and `P>1` comparisons.
+except `D`, `P`, and `B` identical between scalar, batched, and distributed
+comparisons.
 
-Validate the topology guards separately. Both commands must fail before model
+Validate the execution guards separately. These commands must fail before model
 loading:
 
 ```bash
@@ -114,18 +145,35 @@ CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node 2 \
   -i input.json -o output_invalid_world -n opendde_v1 \
   --seeds 101,102,103,104 \
   --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
+
+# Seed batching is not supported with Fold-CP P=2.
+CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node 2 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_invalid_batched_foldcp -n opendde_v1 \
+  --seeds 101,102 --seed_batch_size 2 \
+  --foldcp_mode distributed --foldcp_size_dp 1 --foldcp_size_cp 2
+
+# Training-Free Guidance requires B=1.
+CUDA_VISIBLE_DEVICES=0 python -m runner.batch_inference pred \
+  -i input.json -o output_invalid_batched_tfg -n opendde_v1 \
+  --seeds 101,102 --seed_batch_size 2 --use_tfg_guidance true
 ```
 
 ## Validating numerical alignment
 
 - Use the same Git commit, checkpoint, input JSON, MSA/template features, seed,
   dtype, cycle count, diffusion steps, and kernel settings for every run.
-- For `D x 1`, verify that every requested `(job, seed)` directory exists
-  exactly once and no other seed directory was produced.
+- For every `D x 1, B` run, verify that each requested `(job, seed)` directory
+  exists exactly once and no other seed directory was produced.
 - Verify output schemas, tensor shapes, atom ordering, and finite values before
   comparing numerical values.
 - Compare prediction coordinates and summary-confidence outputs with tolerances
   appropriate for the selected dtype and deterministic settings.
+- Compare each seed in a batch against the same seed from the scalar run;
+  `N_sample` remains independent of `B`.
+- Record observed BF16 deltas: batch-shaped kernels can use different
+  floating-point launch geometry, so bitwise identity is not expected even
+  though per-seed random streams remain independent.
 - Do not use file hashes as the only numerical-alignment check; metadata and
   serialization details can change without changing the prediction.
 - Save the outputs for every compared rank count so the result can be audited.
@@ -139,12 +187,13 @@ Record and publish all of the following with any benchmark claim:
 - the complete command line and relevant environment variables;
 - Python, PyTorch, Triton, CUDA, driver, and container versions;
 - GPU model, GPU count, host topology, and allocator settings;
-- raw per-rank timing logs and GPU memory samples;
+- `D`, `P`, `B`, raw per-rank timing logs, and GPU memory samples;
 - whether timing covers model forward only or end-to-end preprocessing and
   inference;
 - deterministic settings and the numerical-alignment result.
 
-Measure the `P=1` reference and every `P>1` run from the same checkout and
-environment. Do not present a single successful run as a supported production
+Measure scalar `B=1`, each batched width, and every `P>1` run from the same
+checkout and environment. Report OOM widths as failures, not as automatic
+fallbacks. Do not present a single successful run as a supported production
 capacity limit, and do not carry performance or capacity conclusions across
 code, checkpoint, input, kernel, or hardware changes without remeasurement.

--- a/docs/inference_instructions.md
+++ b/docs/inference_instructions.md
@@ -241,37 +241,65 @@ Device auto-selection uses NVIDIA CUDA when available and otherwise CPU.
 cuEquivariance is selected only when its Linux CUDA packages import successfully;
 otherwise the model uses PyTorch triangle kernels.
 
-## Multi-GPU inference
+## Seed batching and multi-GPU inference
 
-The existing topology flags support serial inference, independent seed lanes,
-or Fold-CP. Let `D=--foldcp_size_dp` and `P=--foldcp_size_cp`:
+Let `D=--foldcp_size_dp`, `P=--foldcp_size_cp`, and
+`B=--seed_batch_size`. `D` and `P` define process placement; `B` is the maximum
+number of seeds in one rank-local model batch and defaults to `1`.
 
-| Mode | `foldcp_mode` | `D` | `P` | Required world size |
-| --- | --- | ---: | ---: | ---: |
-| Serial | `single` | 1 | 1 | 1 |
-| Seed parallel | `single` | >1 | 1 | `D` |
-| Fold-CP | `distributed` | 1 | >1 | `P` |
-| Hybrid | - | >1 | >1 | Rejected |
+| Mode | `foldcp_mode` | `D` | `P` | `B` | Required world size |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Scalar single GPU | `single` | 1 | 1 | 1 | 1 |
+| Batched single GPU | `single` | 1 | 1 | >1 | 1 |
+| Sharded seed batches | `single` | >1 | 1 | >=1 | `D` |
+| Fold-CP | `distributed` | 1 | >1 | 1 | `P` |
+| Batched Fold-CP | - | any | >1 | >1 | Rejected |
+| Hybrid | - | >1 | >1 | any | Rejected |
 
 `WORLD_SIZE` must equal `D * P`. Hybrid and mismatched-world-size launches fail
 instead of falling back to serial inference. Multi-GPU inference in this release
 is single-node and requires all ranks to share the input and output filesystem.
 
-### Seed parallel `D x 1`
+### Rank-local seed batches
 
-Seed parallelism runs the normal single-card model independently on each GPU.
-Rank `r` receives `seeds[r::D]`, so seeds must be unique and their count must be
-at least `D`. For example:
+On one GPU, set `D=1, P=1` and choose `B>1`:
+
+```bash
+opendde pred \
+  -i input.json -o output_b2 -n opendde_v1 \
+  --seeds 101,102 \
+  --seed_batch_size 2
+```
+
+Multi-GPU execution uses the same path after assigning rank `r` the ordered
+slice `seeds[r::D]`. Each rank chunks that slice into groups of at most `B`, so
+a smaller final batch is valid. For example, four GPUs with two seeds per GPU
+use:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node 4 \
   -m runner.batch_inference pred \
-  -i input.json -o output_dp4 -n opendde_v1 \
-  --seeds 101,102,103,104 \
+  -i input.json -o output_d4_b2 -n opendde_v1 \
+  --seeds 101,102,103,104,105,106,107,108 \
+  --seed_batch_size 2 \
   --foldcp_mode single \
   --foldcp_size_dp 4 \
   --foldcp_size_cp 1
 ```
+
+Seed batches use a leading model dimension separate from `--sample`: model
+tensors are shaped conceptually as `[B_seed, N_sample, ...]`. Outputs are split
+after model inference and remain one directory per seed. Seeds must be unique
+when either `D>1` or `B>1`, and multi-rank runs require at least `D` seeds.
+Per-seed random streams remain independent, but BF16 predictions need not be
+bitwise identical across batch widths because batched kernels can use different
+floating-point launch geometry.
+
+`B>1` requires `P=1`, `num_workers=0`, `model.N_model_seed=1`, and Training-Free
+Guidance disabled.
+OpenDDE does not choose a width, automatically reduce it, or retry seeds
+serially after an OOM; select a batch size that fits the input and GPU. `B=1`
+preserves the previous tensor shapes and memory profile.
 
 ### Fold-CP `1 x P`
 
@@ -321,7 +349,8 @@ Runtime notes:
   and memory metrics.
 
 For single-GPU inference, omit the topology flags or set
-`--foldcp_mode single --foldcp_size_dp 1 --foldcp_size_cp 1`.
+`--foldcp_mode single --foldcp_size_dp 1 --foldcp_size_cp 1`. Fold-CP requires
+the default `--seed_batch_size 1`.
 
 Use prepared features:
 
@@ -341,6 +370,8 @@ OpenDDE includes default-off Training-Free Guidance (TFG) for protein-ligand
 runs. TFG refines each sampled trajectory with geometry potentials while keeping
 the requested `--sample` count unchanged.
 
+`model.N_model_seed>1` and TFG currently require `--seed_batch_size 1`.
+
 ```bash
 opendde pred -i examples/input.json -o ./output -n opendde_v1 \
   --use_tfg_guidance true
@@ -359,12 +390,13 @@ Outputs are written to:
 | `-n`, `--model_name` | Model name. Currently `opendde_v1`. |
 | `--load_checkpoint_path` | Explicit checkpoint path. |
 | `--seeds` | Comma-separated seeds, e.g. `101,102`. Overrides the job's `modelSeeds`; if unset, `modelSeeds` are used, or a random seed when both are absent. |
+| `--seed_batch_size` | Maximum seeds in one rank-local model batch. Defaults to `1`; values greater than one require `P=1`, `num_workers=0`, `model.N_model_seed=1`, and TFG disabled. |
 | `--use_msa` | Use/generate protein MSA features. |
 | `--use_template` | Use/generate template features. |
 | `--use_rna_msa` | Use/generate RNA MSA features. |
 | `--use_tfg_guidance` | Enable Training-Free Guidance. |
 | `--foldcp_mode` | Use `single` for serial or seed-parallel inference and `distributed` only for `1 x P` Fold-CP. |
-| `--foldcp_size_dp` | Number of independent seed lanes; values greater than one require `P=1`. |
+| `--foldcp_size_dp` | Number of seed-sharding ranks; values greater than one require `P=1`. |
 | `--foldcp_size_cp` | Number of Fold-CP ranks per seed; values greater than one require `D=1`. |
 | `--foldcp_devices` | Optional visible-device list recorded in Fold-CP metrics; actual GPU visibility is controlled by `CUDA_VISIBLE_DEVICES`. |
 | `--foldcp_metrics_jsonl` | Optional JSONL path for Fold-CP timing and memory metrics. |

--- a/docs/inference_instructions.md
+++ b/docs/inference_instructions.md
@@ -241,7 +241,39 @@ Device auto-selection uses NVIDIA CUDA when available and otherwise CPU.
 cuEquivariance is selected only when its Linux CUDA packages import successfully;
 otherwise the model uses PyTorch triangle kernels.
 
-## Multi-GPU Fold-CP inference
+## Multi-GPU inference
+
+The existing topology flags support serial inference, independent seed lanes,
+or Fold-CP. Let `D=--foldcp_size_dp` and `P=--foldcp_size_cp`:
+
+| Mode | `foldcp_mode` | `D` | `P` | Required world size |
+| --- | --- | ---: | ---: | ---: |
+| Serial | `single` | 1 | 1 | 1 |
+| Seed parallel | `single` | >1 | 1 | `D` |
+| Fold-CP | `distributed` | 1 | >1 | `P` |
+| Hybrid | - | >1 | >1 | Rejected |
+
+`WORLD_SIZE` must equal `D * P`. Hybrid and mismatched-world-size launches fail
+instead of falling back to serial inference. Multi-GPU inference in this release
+is single-node and requires all ranks to share the input and output filesystem.
+
+### Seed parallel `D x 1`
+
+Seed parallelism runs the normal single-card model independently on each GPU.
+Rank `r` receives `seeds[r::D]`, so seeds must be unique and their count must be
+at least `D`. For example:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node 4 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_dp4 -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --foldcp_mode single \
+  --foldcp_size_dp 4 \
+  --foldcp_size_cp 1
+```
+
+### Fold-CP `1 x P`
 
 > [!IMPORTANT]
 > Fold-CP inference does not currently support cuEquivariance (`cueq`) triangle
@@ -288,8 +320,8 @@ Runtime notes:
 - Optional `--foldcp_metrics_jsonl path/to/metrics.jsonl` records Fold-CP timing
   and memory metrics.
 
-For single-GPU inference, omit the Fold-CP flags or set
-`--foldcp_mode single --foldcp_size_cp 1`.
+For single-GPU inference, omit the topology flags or set
+`--foldcp_mode single --foldcp_size_dp 1 --foldcp_size_cp 1`.
 
 Use prepared features:
 
@@ -331,9 +363,9 @@ Outputs are written to:
 | `--use_template` | Use/generate template features. |
 | `--use_rna_msa` | Use/generate RNA MSA features. |
 | `--use_tfg_guidance` | Enable Training-Free Guidance. |
-| `--foldcp_mode` | `single` or `distributed`; use `distributed` with `torchrun` for multi-GPU Fold-CP inference. |
-| `--foldcp_size_dp` | Number of data-parallel ranks. Use `1` for the documented `1 x P` Fold-CP topology. |
-| `--foldcp_size_cp` | Number of context-parallel ranks in the `1 x P` mesh; must match the launched process count when `size_dp=1`. |
+| `--foldcp_mode` | Use `single` for serial or seed-parallel inference and `distributed` only for `1 x P` Fold-CP. |
+| `--foldcp_size_dp` | Number of independent seed lanes; values greater than one require `P=1`. |
+| `--foldcp_size_cp` | Number of Fold-CP ranks per seed; values greater than one require `D=1`. |
 | `--foldcp_devices` | Optional visible-device list recorded in Fold-CP metrics; actual GPU visibility is controlled by `CUDA_VISIBLE_DEVICES`. |
 | `--foldcp_metrics_jsonl` | Optional JSONL path for Fold-CP timing and memory metrics. |
 | `--dtype` | `bf16` or `fp32`. |

--- a/docs/seed_parallel_inference_impl.md
+++ b/docs/seed_parallel_inference_impl.md
@@ -1,0 +1,308 @@
+# Seed-Parallel Inference Implementation
+
+Status: Implemented and qualified
+Date: 2026-08-25
+Source: `docs/seed_parallel_inference_spec.md`
+
+Implement the specification as a minimal runner-level extension. Do not change
+model computation or add another parallelism/configuration system.
+
+## Current behavior and gap
+
+- `runner/inference.py::infer_predict()` runs every resolved seed serially on
+  every rank.
+- `opendde/data/inference/infer_dataloader.py` uses `DistributedSampler`, which
+  can give cooperating Fold-CP ranks different jobs.
+- `FoldCPConfig` accepts `size_dp > 1`, but no seed ownership is assigned to
+  data-parallel ranks.
+- Distributed input preprocessing and randomly generated seed selection are not
+  single-owner operations end to end.
+- Existing model and output-rank logic is valid only for `D=1` Fold-CP.
+
+The closest implementation is the current `torchrun` initialization,
+`FoldCPConfig`, rank-0 asset broadcast, scalar seed loop, and per-seed dumper.
+Extend those owners; do not add a launcher, scheduler, model batch dimension, or
+parallel runner.
+
+## Work unit 1: Validate the existing topology
+
+Extend `opendde/distributed/foldcp/config.py` and runner startup:
+
+- preserve serial `D=1, P=1`;
+- allow seed-parallel `D>1, P=1` with `foldcp_mode=single`;
+- preserve Fold-CP `D=1, P>1` with `foldcp_mode=distributed`;
+- reject hybrid `D>1, P>1`;
+- require `WORLD_SIZE == D * P` before checkpoint/model loading; and
+- update the existing launch hint, CLI help, and distributed startup messages
+  for seed-parallel `torchrun`.
+
+Keep `FoldCPConfig.enabled` meaning Fold-CP model sharding. Do not activate the
+Fold-CP model path for `D x 1` seed parallelism.
+
+## Work unit 2: Assign seeds and inputs to ranks
+
+Extend the current runner flow without introducing a new module:
+
+- sort directory JSON inputs once;
+- for each input JSON, run preprocessing on rank 0 and broadcast its path or
+  error;
+- resolve that input's seeds on rank 0 and broadcast the ordered list while
+  preserving the existing first-record `modelSeeds` behavior;
+- reject duplicate seeds and fewer seeds than `D` when `D>1`;
+- select `seeds[DIST_WRAPPER.rank::D]` for `D x 1` execution;
+- use a sequential sampler for distributed inference so each rank sees every
+  input job in the same order; and
+- retain the current seed initialization, prediction, cleanup, and dumping loop
+  for each assigned seed.
+
+Broadcast preprocessing and seed-validation failures to every rank and return a
+nonzero command result. Do not change existing ordinary per-job prediction-error
+handling.
+
+Do not modify `OpenDDE`, diffusion, confidence, Fold-CP mesh, or dumper code.
+With `P=1`, every rank is already an output owner; with `D=1, P>1`, the existing
+global-rank-zero output contract remains valid.
+
+## Work unit 3: Add focused automated tests
+
+Prefer extending `tests/test_inference_config.py` and
+`tests/test_foldcp_cpn.py`; add a new test file only if those files become less
+clear.
+
+Cover:
+
+1. `(WORLD_SIZE,D,P)` support for `(1,1,1)`, `(2,2,1)`, `(3,3,1)`,
+   `(4,4,1)`, `(2,1,2)`, `(3,1,3)`, and `(4,1,4)`.
+2. Rejection of `(4,2,2)`, mode/topology mismatches, and world-size mismatch.
+3. Existing CLI help describing `foldcp_size_dp` seed-lane semantics.
+4. Rank seed slices for even and uneven seed counts with no loss or duplication.
+5. Duplicate and insufficient seed rejection before the first model forward.
+6. Rank-0 success/failure propagation for per-input preprocessing and seed
+   resolution, including a nonzero distributed failure result.
+7. Same ordered multi-record dataset on every distributed rank.
+8. `infer_predict()` invoking and dumping only the rank's assigned seeds.
+9. The unchanged serial cleanup/call path and existing Fold-CP tests.
+
+Run focused checks first:
+
+```bash
+ruff check runner opendde/distributed/foldcp \
+  opendde/data/inference tests/test_inference_config.py tests/test_foldcp_cpn.py
+python -m pytest -q tests/test_inference_config.py tests/test_foldcp_cpn.py
+```
+
+Then run the repository-prescribed non-network suite:
+
+```bash
+python -m pytest tests -q -m "not network"
+```
+
+## Work unit 4: Update public documentation
+
+Update only:
+
+- `README.md`;
+- `docs/inference_instructions.md`;
+- `docs/foldcp_e2e_baseline.md`; and
+- `CHANGELOG.md` under `[Unreleased]`.
+
+Use the existing flag spellings and command style. Explain that
+`foldcp_mode=single` selects the normal one-card model path even when `D>1`.
+Document hybrid rejection and retain all existing Fold-CP kernel restrictions.
+
+## Local four-GPU qualification
+
+Create the documented Python 3.11 GPU environment if the checkout does not yet
+have one. Use the checked-in `examples/foldcp_demo_placeholder.json`, released
+general checkpoint, `LAYERNORM_TYPE=torch`, external features disabled,
+`sample=1`, `step=2`, `cycle=1`, `dtype=fp32`, PyTorch triangle kernels, TF32
+disabled, and deterministic mode.
+
+Run this matrix from the implementation commit:
+
+| Case | World | `D` | `P` | Seeds | Expected |
+| --- | ---: | ---: | ---: | --- | --- |
+| Ordinary serial reference | 1 | 1 | 1 | 101-106 | Success |
+| Seed parallel | 2 | 2 | 1 | 101-106 | Success |
+| Seed parallel | 3 | 3 | 1 | 101-106 | Success |
+| Seed parallel | 4 | 4 | 1 | 101-104 | Success |
+| Two-record seed parallel | 2 | 2 | 1 | 101-104 | Success |
+| Fold-CP | 2 | 1 | 2 | 101 | Success |
+| Fold-CP | 3 | 1 | 3 | 101 | Success |
+| Fold-CP | 4 | 1 | 4 | 101 | Success |
+| Hybrid guard | 4 | 2 | 2 | 101-104 | Fail before model load |
+| World-size guard | 2 | 4 | 1 | 101-104 | Fail before model load |
+
+Run the ordinary serial reference with `python -m runner.batch_inference pred`
+and omit Fold-CP topology flags. Build the two-record smoke input in a temporary
+directory from the checked-in fixture with distinct job names; do not commit it.
+
+Before the matrix, confirm all selected GPUs are idle. Preserve output and logs
+until comparisons finish. For every success, record exit status, elapsed time,
+peak GPU memory, produced seed/sample paths, schema/finiteness checks, and
+coordinate plus summary-confidence deltas from the matching serial result.
+Report the mixed GPU models/topology and treat timing as diagnostic only.
+
+Do not commit the environment, checkpoints, generated outputs, logs, caches, or
+machine-specific paths.
+
+## Acceptance evidence
+
+Qualification passed on 2026-08-26. The implementation commit is the PR head
+containing this document, based on public `main` at
+`aa53450b5583fdd6f350ed3e1f601deda766c23b` (`v1.1.0`). Runtime code was
+unchanged after the GPU matrix; only this evidence was appended.
+
+Changed owners are limited to the existing topology config, inference runner,
+batch entrypoint, inference dataloader, two existing test files, the SPEC/IMPL,
+and the four required public documentation files. No model, kernel, dumper,
+schema, dependency, or deployment file changed.
+
+### Automated checks
+
+- Focused Ruff: passed.
+- Focused pytest: `94 passed`.
+- Non-network suite: `311 passed, 4 deselected, 44 subtests passed`.
+- `pre-commit run --all-files`: Ruff check and format passed.
+- `ruff format --check` and `git diff --check`: passed.
+
+### Environment and commands
+
+- Python 3.11.14; PyTorch 2.7.1+cu126; CUDA runtime 12.6; NCCL 2.26.2;
+  Triton 3.3.1; NVIDIA driver 590.48.01.
+- Released `opendde.pt`, 2,625,249,069 bytes, SHA-256
+  `7b826620390afad877ee2babc6a4d0df81b94d3a0be030959853d6a7da0807cc`.
+- `CUDA_DEVICE_ORDER=PCI_BUS_ID`; physical GPUs 0-2 were RTX 3090 24 GiB and
+  GPU 3 was an RTX 4090 reported with 49,140 MiB. Local rank followed each
+  `CUDA_VISIBLE_DEVICES` list in order.
+- Three pre-run samples found all four GPUs at 1 MiB, 0% utilization, with no
+  compute processes. No matrix worker remained afterward.
+
+The local runtime-data and temporary-output paths are represented below by
+environment variables so no machine-specific path is committed:
+
+```bash
+export OPENDDE_ROOT_DIR=/path/to/opendde_data
+export QUAL_DIR="$(mktemp -d /tmp/opendde-seed-parallel-XXXXXX)"
+export LAYERNORM_TYPE=torch
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+
+INPUT=examples/foldcp_demo_placeholder.json
+CHECKPOINT="$OPENDDE_ROOT_DIR/checkpoint/opendde.pt"
+COMMON=(
+  -n opendde_v1 --load_checkpoint_path "$CHECKPOINT"
+  --use_msa false --use_template false --use_rna_msa false
+  --sample 1 --step 2 --cycle 1 --dtype fp32
+  --trimul_kernel torch --triatt_kernel torch
+  --enable_tf32 false --deterministic true
+)
+
+# Ordinary serial reference; no topology flags.
+CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m runner.batch_inference pred \
+  -i "$INPUT" -o "$QUAL_DIR/serial" --seeds 101,102,103,104,105,106 \
+  "${COMMON[@]}"
+
+# D x 1. Set CASE/WORLD/GPUS/SEEDS to the successful DP rows below.
+CUDA_VISIBLE_DEVICES="$GPUS" .venv/bin/torchrun --standalone \
+  --nproc_per_node "$WORLD" -m runner.batch_inference pred \
+  -i "$INPUT" -o "$QUAL_DIR/$CASE" --seeds "$SEEDS" "${COMMON[@]}" \
+  --foldcp_mode single --foldcp_size_dp "$WORLD" --foldcp_size_cp 1
+
+# 1 x P. Set CASE/WORLD/GPUS to the successful CP rows below.
+CUDA_VISIBLE_DEVICES="$GPUS" .venv/bin/torchrun --standalone \
+  --nproc_per_node "$WORLD" -m runner.batch_inference pred \
+  -i "$INPUT" -o "$QUAL_DIR/$CASE" --seeds 101 "${COMMON[@]}" \
+  --foldcp_mode distributed --foldcp_size_dp 1 --foldcp_size_cp "$WORLD"
+
+# Matched two-record reference and D2 run.
+TWO_INPUT="$QUAL_DIR/two_records.json"
+CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m runner.batch_inference pred \
+  -i "$TWO_INPUT" -o "$QUAL_DIR/two_serial" --seeds 101,102,103,104 \
+  "${COMMON[@]}"
+CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone \
+  --nproc_per_node 2 -m runner.batch_inference pred \
+  -i "$TWO_INPUT" -o "$QUAL_DIR/two_dp2" --seeds 101,102,103,104 \
+  "${COMMON[@]}" \
+  --foldcp_mode single --foldcp_size_dp 2 --foldcp_size_cp 1
+
+# Rejected hybrid and mismatched-world-size launches.
+CUDA_VISIBLE_DEVICES=0,1,2,3 .venv/bin/torchrun --standalone \
+  --nproc_per_node 4 -m runner.batch_inference pred \
+  -i "$INPUT" -o "$QUAL_DIR/hybrid_guard" --seeds 101,102,103,104 \
+  "${COMMON[@]}" \
+  --foldcp_mode distributed --foldcp_size_dp 2 --foldcp_size_cp 2
+CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone \
+  --nproc_per_node 2 -m runner.batch_inference pred \
+  -i "$INPUT" -o "$QUAL_DIR/world_guard" --seeds 101,102,103,104 \
+  "${COMMON[@]}" \
+  --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
+```
+
+The two-record input was a temporary copy of the checked-in 40-residue record
+with names `foldcp_demo_first` and `foldcp_demo_second`. It was run serially and
+with `D=2` using seeds 101-104. The guard commands used the distributed template
+with `(WORLD,D,P)=(4,2,2)` and the seed-parallel template with `(2,4,1)`.
+Every command had a 900-second timeout and a 200 ms `nvidia-smi` memory trace.
+For each `WORLD=N` row, `GPUS` was `0,...,N-1`; `CASE` and `SEEDS` match the
+matrix entries.
+
+### Four-GPU matrix
+
+Peak memory lists selected physical GPUs in local-rank order. Elapsed time is
+end to end and is diagnostic only on this heterogeneous host.
+
+| Case | World | `D` | `P` | Seeds | Result | Elapsed (s) | Peak MiB |
+| --- | ---: | ---: | ---: | --- | --- | ---: | --- |
+| Serial reference | 1 | 1 | 1 | 101-106 | Pass (0) | 21.147 | 5722 |
+| Seed parallel D2 | 2 | 2 | 1 | 101-106 | Pass (0) | 20.461 | 5888 / 5888 |
+| Seed parallel D3 | 3 | 3 | 1 | 101-106 | Pass (0) | 20.595 | 5876 / 5876 / 5876 |
+| Seed parallel D4 | 4 | 4 | 1 | 101-104 | Pass (0) | 19.414 | 5876 / 5876 / 5876 / 6046 |
+| Two-record serial | 1 | 1 | 1 | 101-104 | Pass (0) | 21.718 | 5722 |
+| Two-record D2 | 2 | 2 | 1 | 101-104 | Pass (0) | 20.091 | 5888 / 5888 |
+| Fold-CP P2 | 2 | 1 | 2 | 101 | Pass (0) | 23.085 | 5888 / 5888 |
+| Fold-CP P3 | 3 | 1 | 3 | 101 | Pass (0) | 23.569 | 5876 / 5876 / 5876 |
+| Fold-CP P4 | 4 | 1 | 4 | 101 | Pass (0) | 24.184 | 5876 / 5876 / 5876 / 6046 |
+| Hybrid guard | 4 | 2 | 2 | 101-104 | Expected fail (1) | 4.895 | 1 / 1 / 1 / 1 |
+| World-size guard | 2 | 4 | 1 | 101-104 | Expected fail (1) | 4.947 | 1 / 1 |
+
+Both guards failed without `Loading from`, wrote no prediction CIF, and exited
+without a timeout or lingering worker. Successful cases produced exactly one
+CIF, summary-confidence JSON, and full-data JSON per expected `(job, seed)`.
+
+### Numerical alignment
+
+Every CIF had the same atom-site schema and exact atom identity/order as its
+matched serial result (335 atoms), and all CIF/full-data/summary numeric values
+were finite. Coordinates and every numeric summary-confidence leaf were checked
+with `numpy.testing.assert_allclose(atol=5e-4, rtol=5e-4)`:
+
+| Candidate | Compared `(job, seed)` pairs | Max coordinate abs delta | Max B-factor abs delta | Max summary abs delta |
+| --- | ---: | ---: | ---: | ---: |
+| D2 | 6 | 0 | 0 | 0 |
+| D3 | 6 | 0 | 0 | 0 |
+| D4 | 4 | 0.001 | 0.02 | 0.0000991821 |
+| Fold-CP P2 | 1 | 0.001 | 0.03 | 0.0003738403 |
+| Fold-CP P3 | 1 | 0.001 | 0.03 | 0.0003738403 |
+| Fold-CP P4 | 1 | 0.001 | 0.03 | 0.0012588501 |
+| Two-record D2 | 8 | 0 | 0 | 0 |
+
+All comparisons passed the stated absolute/relative tolerance. D4's nonzero
+deltas were confined to seed 104 on rank 3 (the RTX 4090); seeds 101-103 on the
+three RTX 3090 ranks had zero recorded deltas. Fold-CP's small deltas were also
+present on homogeneous RTX 3090 P2/P3 runs and are attributable to its changed
+parallel reduction order plus CIF decimal serialization. No seed, sample, atom,
+or schema divergence occurred.
+
+## Complexity inventory
+
+- New CLI flags or config keys: none.
+- New model, kernel, output, or input paths: none.
+- New dependencies, services, scripts, or abstractions: none.
+- Required code owners changed: existing config, runner, and inference sampler
+  only.
+
+## Non-goals
+
+The SPEC non-goals are binding, especially same-GPU seed batching, hybrid
+`D x P`, model changes, automatic sizing/retry, and Predictify integration.

--- a/docs/seed_parallel_inference_impl.md
+++ b/docs/seed_parallel_inference_impl.md
@@ -1,6 +1,6 @@
 # Seed-Parallel Inference Implementation
 
-Status: Implementation and qualification in progress
+Status: Implemented and locally qualified
 Date: 2026-08-26
 Source: `docs/seed_parallel_inference_spec.md`
 
@@ -170,10 +170,83 @@ logs, caches, or machine-specific paths.
 
 ## Acceptance evidence
 
-Append final commands and results here only after the implementation commit has
-passed the automated checks and local matrix. Prior `D x 1` results measured
-rank sharding with scalar per-seed model calls and are not evidence for
-same-GPU batching.
+Implementation commit: `b0a5ddb`.
+
+Automated qualification passed with `335 passed, 4 deselected, 44 subtests
+passed` for the non-network suite. `ruff check .`, `ruff format --check .`, and
+`git diff --check` also passed. The focused model-stage test executes a real
+small `DiffusionModule` and `ConfidenceHead` with `B=2, N_sample=2` and compares
+both seed lanes with scalar calls.
+
+Local GPU qualification used BF16, deterministic algorithms, TF32 disabled,
+MSA enabled, one recycle, two diffusion steps, and one sample unless stated
+otherwise. End-to-end time includes process startup, model load, featurization,
+model execution, and output writing. Peak memory was sampled every 200 ms with
+`nvidia-smi`. The released checkpoint was 2,625,249,069 bytes with SHA-256
+`7b826620390afad877ee2babc6a4d0df81b94d3a0be030959853d6a7da0807cc`.
+
+The scalar time in this table runs the same number of seeds sequentially with
+`B=1`. `Max B` succeeded and the next explicit width OOMed; no run retried at a
+smaller width.
+
+| GPU | MSA case (`N_token/N_atom/N_msa`) | Max B | Next | B=1 time (s) | Batched time (s) | Speedup | B=1 / batched peak MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| RTX 3090 24 GiB | 7R6R (`245/2529/703`) | 10 | 11 OOM | 48.382 | 42.725 | 1.132x | 6,138 / 23,208 |
+| RTX 3090 24 GiB | 5SAK (`437/3074/9667`) | 3 | 4 OOM | 51.854 | 49.732 | 1.043x | 12,414 / 21,408 |
+| RTX 3090 24 GiB | 7ST3 (`545/4281/12707`) | 2 | 3 OOM | 59.024 | 55.422 | 1.065x | 17,530 / 23,630 |
+| RTX 3090 24 GiB | 7PZB single copy (`300/2611/12424`) | 7 | 8 OOM | 55.550 | 54.588 | 1.018x | 7,470 / 23,432 |
+| RTX 3090 24 GiB | 9FM7 single copy (`322/2186/8856`) | 6 | 7 OOM | 48.137 | 53.557 | 0.899x | 7,722 / 23,748 |
+| RTX 4090 48 GiB | 7R6R (`245/2529/703`) | 21 | 22 OOM | 66.965 | 57.812 | 1.158x | 6,290 / 47,884 |
+| RTX 4090 48 GiB | 5SAK (`437/3074/9667`) | 7 | 8 OOM | 63.147 | 60.595 | 1.042x | 12,566 / 46,866 |
+| RTX 4090 48 GiB | 7ST3 (`545/4281/12707`) | 4 | 5 OOM | 59.662 | 71.813 | 0.831x | 17,682 / 46,320 |
+| RTX 4090 48 GiB | 7PZB single copy (`300/2611/12424`) | 13 | 14 OOM | 66.031 | 58.972 | 1.120x | 7,622 / 45,992 |
+| RTX 4090 48 GiB | 9FM7 single copy (`322/2186/8856`) | 14 | 15 OOM | 73.820 | 66.703 | 1.107x | 7,874 / 46,950 |
+
+The checked-in 7PZB and 9FM7 examples describe doubled assemblies. Their real
+single-copy protein/nucleic-acid or ligand assemblies were used so the required
+`B=2` control fits on a 24 GiB GPU; both retain their checked-in MSA features.
+The full doubled assemblies explicitly OOMed at `B=2` on the RTX 3090.
+
+A longer 7R6R control used ten recycles and 200 diffusion steps for the same two
+seeds:
+
+| GPU | B=1 / B=2 time (s) | Speedup | B=1 / B=2 peak MiB | B=1 / B=2 seeds/min |
+| --- | ---: | ---: | ---: | ---: |
+| RTX 3090 | 69.839 / 64.607 | 1.081x | 6,138 / 9,116 | 1.718 / 1.857 |
+| RTX 4090 | 58.003 / 50.534 | 1.148x | 6,290 / 9,268 | 2.069 / 2.375 |
+
+The unified sharding-plus-batching path produced exactly eight seed outputs for
+`D=4, P=1, B=2` and the expected rank-strided assignments. The same 7R6R test
+completed in 24.675 s for `D=2` (four seeds), 25.215 s for `D=3` (six seeds),
+and 25.750 s for `D=4` (eight seeds), at approximately 9.2 GiB per rank. A
+single-GPU `B=2` run with three seeds also completed its `[2, 1]` partial tail.
+
+The 7EOW antibody-antigen case used `N_sample=2` and the ABAG checkpoint,
+2,625,271,509 bytes with SHA-256
+`5cf37441ddef2a2f148b81dd4a218ad274f996fecaf17dec901ab6cf1351713d`.
+Four fixed seeds with `B=1` completed in 45.887, 33.958, 34.351, and 27.091 s
+for `D=1,2,3,4`, respectively; `D=4` peaked at 10,106/10,106/10,106/10,274
+MiB. On one RTX 4090, two seeds in one true batch completed in 30.032 s at
+44,934 MiB versus 29.691 s at 24,982 MiB for sequential `B=1`; `B=2` OOMed on
+the RTX 3090. This large case is memory-bound and does not benefit from local
+batching.
+
+Existing Fold-CP remained scalar in the seed dimension: `P=2,3,4`, `B=1`
+completed the small regression in 23.695, 24.283, and 24.804 s with one output
+and approximately 5.8-6.0 GiB per rank. The batched Fold-CP, hybrid topology,
+world-size, worker, nested-model-seed, and TFG guards all failed before model
+selection or loading as specified.
+
+Every successful comparison had the exact requested seed/sample cardinality,
+matching CIF schema and atom identity/order, and finite CIF and JSON values.
+Per-lane MSA permutations and diffusion random draws matched scalar streams in
+focused tests. End-to-end BF16 predictions were not bitwise equivalent: across
+the five maximum-width cases, maximum absolute coordinate deltas versus scalar
+runs ranged from 3.59 to 37.98 Angstrom on the RTX 4090 and 3.63 to 32.86
+Angstrom on the RTX 3090; maximum summary-confidence deltas ranged from 0.061 to
+0.663 and 0.074 to 0.671, respectively. These observed deltas are recorded, not
+accepted as a numerical tolerance; maximum-capacity widths are likewise not a
+throughput recommendation.
 
 ## Complexity inventory
 

--- a/docs/seed_parallel_inference_impl.md
+++ b/docs/seed_parallel_inference_impl.md
@@ -1,103 +1,117 @@
 # Seed-Parallel Inference Implementation
 
-Status: Implemented and qualified
-Date: 2026-08-25
+Status: Implementation and qualification in progress
+Date: 2026-08-26
 Source: `docs/seed_parallel_inference_spec.md`
 
-Implement the specification as a minimal runner-level extension. Do not change
-model computation or add another parallelism/configuration system.
+Implement seed batching as a minimal extension of the normal model path. One
+rank-local scheduler owns seed assignment and batching for both single- and
+multi-GPU execution; multi-GPU execution only gives that scheduler a strided
+subset of the seeds.
 
 ## Current behavior and gap
 
-- `runner/inference.py::infer_predict()` runs every resolved seed serially on
-  every rank.
-- `opendde/data/inference/infer_dataloader.py` uses `DistributedSampler`, which
-  can give cooperating Fold-CP ranks different jobs.
-- `FoldCPConfig` accepts `size_dp > 1`, but no seed ownership is assigned to
-  data-parallel ranks.
-- Distributed input preprocessing and randomly generated seed selection are not
-  single-owner operations end to end.
-- Existing model and output-rank logic is valid only for `D=1` Fold-CP.
+The prior seed-parallel implementation assigned `seeds[rank::D]` but still ran
+one full model call for every seed. It therefore provided multi-GPU seed
+sharding, not same-GPU seed batching.
 
-The closest implementation is the current `torchrun` initialization,
-`FoldCPConfig`, rank-0 asset broadcast, scalar seed loop, and per-seed dumper.
-Extend those owners; do not add a launcher, scheduler, model batch dimension, or
-parallel runner.
+Using `N_sample` as a substitute is incorrect: samples share the seed's
+featurization and trunk state, while independent seeds affect MSA sampling,
+reference features, diffusion noise, and other random inputs. True seed
+batching requires a separate leading model dimension and independent random
+streams.
 
-## Work unit 1: Validate the existing topology
+## Work unit 1: Expose one batch-width control
 
-Extend `opendde/distributed/foldcp/config.py` and runner startup:
+Add `seed_batch_size: 1` to the inference defaults/schema and expose it as
+`--seed_batch_size` on `opendde pred`.
 
-- preserve serial `D=1, P=1`;
-- allow seed-parallel `D>1, P=1` with `foldcp_mode=single`;
-- preserve Fold-CP `D=1, P>1` with `foldcp_mode=distributed`;
-- reject hybrid `D>1, P>1`;
-- require `WORLD_SIZE == D * P` before checkpoint/model loading; and
-- update the existing launch hint, CLI help, and distributed startup messages
-  for seed-parallel `torchrun`.
+- Treat the value as the maximum rank-local batch width, not a GPU count.
+- Preserve `B=1` as the compatibility default.
+- Pass the value through existing runner construction; do not add a launcher or
+  a second inference entrypoint.
+- Validate `B >= 1` before model loading.
 
-Keep `FoldCPConfig.enabled` meaning Fold-CP model sharding. Do not activate the
-Fold-CP model path for `D x 1` seed parallelism.
+## Work unit 2: Unify rank sharding and local batching
 
-## Work unit 2: Assign seeds and inputs to ranks
+Keep seed resolution and distributed input handling in the existing inference
+runner:
 
-Extend the current runner flow without introducing a new module:
+1. Sort directory inputs on every rank; for multi-rank runs, preprocess each
+   input once on rank 0 and broadcast the shared path or failure.
+2. Resolve and broadcast the ordered seed list.
+3. Assign rank `r` the stable slice `seeds[r::D]`.
+4. Chunk that slice in order into batches of at most `B`.
+5. Send every chunk, including an uneven tail, through the same prediction
+   method.
 
-- sort directory JSON inputs once;
-- for each input JSON, run preprocessing on rank 0 and broadcast its path or
-  error;
-- resolve that input's seeds on rank 0 and broadcast the ordered list while
-  preserving the existing first-record `modelSeeds` behavior;
-- reject duplicate seeds and fewer seeds than `D` when `D>1`;
-- select `seeds[DIST_WRAPPER.rank::D]` for `D x 1` execution;
-- use a sequential sampler for distributed inference so each rank sees every
-  input job in the same order; and
-- retain the current seed initialization, prediction, cleanup, and dumping loop
-  for each assigned seed.
+There must be no separate single-GPU implementation. `D=1` naturally assigns
+all seeds to rank 0; `D>1` changes only the input slice to the same chunking
+loop.
 
-Broadcast preprocessing and seed-validation failures to every rank and return a
-nonzero command result. Do not change existing ordinary per-job prediction-error
-handling.
+Preserve one featurization iterator and random state per seed across multiple
+input records. Seed-dependent records in a chunk must describe the same job and
+topology before they are stacked. Keep `num_workers=0` mandatory for `B>1`, so
+the runner can preserve those independent random streams without a second
+worker scheduling protocol.
 
-Do not modify `OpenDDE`, diffusion, confidence, Fold-CP mesh, or dumper code.
-With `P=1`, every rank is already an output owner; with `D=1, P>1`, the existing
-global-rank-zero output contract remains valid.
+Reject duplicates when `D>1` or `B>1`, fewer seeds than ranks when `D>1`, and
+all existing topology mismatches. Do not retry an OOM with a smaller batch.
 
-## Work unit 3: Add focused automated tests
+## Work unit 3: Add the seed dimension to the normal model path
 
-Prefer extending `tests/test_inference_config.py` and
-`tests/test_foldcp_cpn.py`; add a new test file only if those files become less
-clear.
+Stack seed-dependent tensors on a leading `B_seed` dimension while verifying
+that shared topology metadata agrees. Carry the normal path as:
+
+```text
+[B_seed, N_sample, ...]
+```
+
+Update only operators that currently assume an unbatched leading shape:
+
+- per-seed MSA row sampling and gather;
+- MSA input projection broadcasting;
+- template feature broadcasting where templates are shared;
+- diffusion random draws;
+- confidence-stage handoff before scalar postprocessing.
+
+Keep independent generators for each seed. Preserve featurization and MSA
+generator state across input records; diffusion derives an independent rollout
+generator from each seed per record. Do not draw one MSA permutation for the
+entire batch.
+
+After batched confidence computation, split `B_seed` before the existing
+non-batch-safe ranking, structure conversion, and dumper path. Each split item
+must retain its original seed, features, atom array, entity metadata, and
+`N_sample` predictions.
+
+Do not add the seed dimension to Fold-CP or Training-Free Guidance. Reject
+`B>1, P>1`, `B>1` with `model.N_model_seed>1`, and `B>1` with Training-Free
+Guidance; retain their existing `B=1` implementations.
+
+## Work unit 4: Add focused automated tests
+
+Extend the closest existing config, runner, MSA, diffusion, and model tests.
+Add a focused seed-batch test module only where no existing owner is clear.
 
 Cover:
 
-1. `(WORLD_SIZE,D,P)` support for `(1,1,1)`, `(2,2,1)`, `(3,3,1)`,
-   `(4,4,1)`, `(2,1,2)`, `(3,1,3)`, and `(4,1,4)`.
-2. Rejection of `(4,2,2)`, mode/topology mismatches, and world-size mismatch.
-3. Existing CLI help describing `foldcp_size_dp` seed-lane semantics.
-4. Rank seed slices for even and uneven seed counts with no loss or duplication.
-5. Duplicate and insufficient seed rejection before the first model forward.
-6. Rank-0 success/failure propagation for per-input preprocessing and seed
-   resolution, including a nonzero distributed failure result.
-7. Same ordered multi-record dataset on every distributed rank.
-8. `infer_predict()` invoking and dumping only the rank's assigned seeds.
-9. The unchanged serial cleanup/call path and existing Fold-CP tests.
+1. CLI/default/schema propagation for `B=1` and explicit widths.
+2. Rank-strided assignment followed by ordered chunks for `D=1-4`, including a
+   partial tail.
+3. Duplicate, insufficient-seed, `B<1`, `B>1/P>1`, nonzero-worker, and TFG
+   guards.
+4. Per-lane MSA and diffusion random streams matching equivalent scalar calls.
+5. Batched model shapes with `B_seed>1` and `N_sample>1`.
+6. Per-seed postprocessing and exactly-once dumping.
+7. Unified prediction-call behavior for `D=1` and `D>1`.
+8. Existing scalar and Fold-CP regression tests.
 
-Run focused checks first:
+Run focused checks first, followed by the repository-prescribed non-network
+suite and formatting checks. GPU-only equivalence belongs in the local
+qualification matrix, not a network-dependent unit test.
 
-```bash
-ruff check runner opendde/distributed/foldcp \
-  opendde/data/inference tests/test_inference_config.py tests/test_foldcp_cpn.py
-python -m pytest -q tests/test_inference_config.py tests/test_foldcp_cpn.py
-```
-
-Then run the repository-prescribed non-network suite:
-
-```bash
-python -m pytest tests -q -m "not network"
-```
-
-## Work unit 4: Update public documentation
+## Work unit 5: Update public documentation
 
 Update only:
 
@@ -106,203 +120,71 @@ Update only:
 - `docs/foldcp_e2e_baseline.md`; and
 - `CHANGELOG.md` under `[Unreleased]`.
 
-Use the existing flag spellings and command style. Explain that
-`foldcp_mode=single` selects the normal one-card model path even when `D>1`.
-Document hybrid rejection and retain all existing Fold-CP kernel restrictions.
+Use the existing flag spelling and command style. Document the default,
+rank-first assignment, partial batches, Fold-CP restriction, worker restriction,
+per-seed outputs, and explicit no-retry behavior.
 
 ## Local four-GPU qualification
 
-Create the documented Python 3.11 GPU environment if the checkout does not yet
-have one. Use the checked-in `examples/foldcp_demo_placeholder.json`, released
-general checkpoint, `LAYERNORM_TYPE=torch`, external features disabled,
-`sample=1`, `step=2`, `cycle=1`, `dtype=fp32`, PyTorch triangle kernels, TF32
-disabled, and deterministic mode.
+Run from the final implementation commit with all selected GPUs idle. Record
+raw end-to-end time and sampled peak memory per GPU, and preserve logs and
+outputs until numerical comparisons finish.
 
-Run this matrix from the implementation commit:
+The correctness matrix must include:
 
-| Case | World | `D` | `P` | Seeds | Expected |
-| --- | ---: | ---: | ---: | --- | --- |
-| Ordinary serial reference | 1 | 1 | 1 | 101-106 | Success |
-| Seed parallel | 2 | 2 | 1 | 101-106 | Success |
-| Seed parallel | 3 | 3 | 1 | 101-106 | Success |
-| Seed parallel | 4 | 4 | 1 | 101-104 | Success |
-| Two-record seed parallel | 2 | 2 | 1 | 101-104 | Success |
-| Fold-CP | 2 | 1 | 2 | 101 | Success |
-| Fold-CP | 3 | 1 | 3 | 101 | Success |
-| Fold-CP | 4 | 1 | 4 | 101 | Success |
-| Hybrid guard | 4 | 2 | 2 | 101-104 | Fail before model load |
-| World-size guard | 2 | 4 | 1 | 101-104 | Fail before model load |
+| Case | World | `D` | `P` | `B` | Expected |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Scalar reference | 1 | 1 | 1 | 1 | Success |
+| Same-GPU batch | 1 | 1 | 1 | 2+ | Success |
+| Partial tail | 1 | 1 | 1 | 2 | Success with three seeds |
+| Sharded batches | 2 | 2 | 1 | 2 | Success |
+| Sharded batches | 3 | 3 | 1 | 2 | Success |
+| Sharded batches | 4 | 4 | 1 | 2 | Success |
+| Fold-CP | 2-4 | 1 | 2-4 | 1 | Success |
+| Batched Fold-CP guard | 2 | 1 | 2 | 2 | Fail before inference |
+| Hybrid guard | 4 | 2 | 2 | 1 | Fail before model load |
+| World-size guard | 2 | 4 | 1 | 1 | Fail before model load |
 
-Run the ordinary serial reference with `python -m runner.batch_inference pred`
-and omit Fold-CP topology flags. Build the two-record smoke input in a temporary
-directory from the checked-in fixture with distinct job names; do not commit it.
+For real-input capacity and performance evidence:
 
-Before the matrix, confirm all selected GPUs are idle. Preserve output and logs
-until comparisons finish. For every success, record exit status, elapsed time,
-peak GPU memory, produced seed/sample paths, schema/finiteness checks, and
-coordinate plus summary-confidence deltas from the matching serial result.
-Report the mixed GPU models/topology and treat timing as diagnostic only.
+- run the five checked-in MSA examples for 7R6R, 5SAK, 7ST3, 7PZB, and 9FM7
+  in BF16 on both an RTX 3090 and RTX 4090;
+- start at `B=1`, verify `B=2`, and increase `B` until the largest explicit
+  width that fits each `(input, GPU)` is established without automatic retry;
+- compare each produced seed against its scalar result and report throughput,
+  speedup, and peak memory; and
+- exercise 7EOW with the ABAG checkpoint across world sizes 1-4, using the same
+  rank-local batching path and reporting per-rank memory.
 
-Do not commit the environment, checkpoints, generated outputs, logs, caches, or
-machine-specific paths.
+For every success, verify the exact set of seed/sample outputs, CIF schema,
+atom identity/order, and finite values. Compare coordinates and
+summary-confidence values against the matched scalar result and report the
+observed deltas; BF16 batch-shaped kernels are not expected to be bitwise
+identical to scalar launches. Record the commit, checkpoint identity, complete
+commands, environment, GPU mapping, timing boundary, raw time, and peak memory.
+Treat heterogeneous-host timings as local evidence, not portable performance
+claims.
+
+Do not commit runtime environments, checkpoints, generated inputs, outputs,
+logs, caches, or machine-specific paths.
 
 ## Acceptance evidence
 
-Qualification passed on 2026-08-26. The implementation commit is the PR head
-containing this document, based on public `main` at
-`aa53450b5583fdd6f350ed3e1f601deda766c23b` (`v1.1.0`). Runtime code was
-unchanged after the GPU matrix; only this evidence was appended.
-
-Changed owners are limited to the existing topology config, inference runner,
-batch entrypoint, inference dataloader, two existing test files, the SPEC/IMPL,
-and the four required public documentation files. No model, kernel, dumper,
-schema, dependency, or deployment file changed.
-
-### Automated checks
-
-- Focused Ruff: passed.
-- Focused pytest: `94 passed`.
-- Non-network suite: `311 passed, 4 deselected, 44 subtests passed`.
-- `pre-commit run --all-files`: Ruff check and format passed.
-- `ruff format --check` and `git diff --check`: passed.
-
-### Environment and commands
-
-- Python 3.11.14; PyTorch 2.7.1+cu126; CUDA runtime 12.6; NCCL 2.26.2;
-  Triton 3.3.1; NVIDIA driver 590.48.01.
-- Released `opendde.pt`, 2,625,249,069 bytes, SHA-256
-  `7b826620390afad877ee2babc6a4d0df81b94d3a0be030959853d6a7da0807cc`.
-- `CUDA_DEVICE_ORDER=PCI_BUS_ID`; physical GPUs 0-2 were RTX 3090 24 GiB and
-  GPU 3 was an RTX 4090 reported with 49,140 MiB. Local rank followed each
-  `CUDA_VISIBLE_DEVICES` list in order.
-- Three pre-run samples found all four GPUs at 1 MiB, 0% utilization, with no
-  compute processes. No matrix worker remained afterward.
-
-The local runtime-data and temporary-output paths are represented below by
-environment variables so no machine-specific path is committed:
-
-```bash
-export OPENDDE_ROOT_DIR=/path/to/opendde_data
-export QUAL_DIR="$(mktemp -d /tmp/opendde-seed-parallel-XXXXXX)"
-export LAYERNORM_TYPE=torch
-export CUBLAS_WORKSPACE_CONFIG=:4096:8
-export CUDA_DEVICE_ORDER=PCI_BUS_ID
-
-INPUT=examples/foldcp_demo_placeholder.json
-CHECKPOINT="$OPENDDE_ROOT_DIR/checkpoint/opendde.pt"
-COMMON=(
-  -n opendde_v1 --load_checkpoint_path "$CHECKPOINT"
-  --use_msa false --use_template false --use_rna_msa false
-  --sample 1 --step 2 --cycle 1 --dtype fp32
-  --trimul_kernel torch --triatt_kernel torch
-  --enable_tf32 false --deterministic true
-)
-
-# Ordinary serial reference; no topology flags.
-CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m runner.batch_inference pred \
-  -i "$INPUT" -o "$QUAL_DIR/serial" --seeds 101,102,103,104,105,106 \
-  "${COMMON[@]}"
-
-# D x 1. Set CASE/WORLD/GPUS/SEEDS to the successful DP rows below.
-CUDA_VISIBLE_DEVICES="$GPUS" .venv/bin/torchrun --standalone \
-  --nproc_per_node "$WORLD" -m runner.batch_inference pred \
-  -i "$INPUT" -o "$QUAL_DIR/$CASE" --seeds "$SEEDS" "${COMMON[@]}" \
-  --foldcp_mode single --foldcp_size_dp "$WORLD" --foldcp_size_cp 1
-
-# 1 x P. Set CASE/WORLD/GPUS to the successful CP rows below.
-CUDA_VISIBLE_DEVICES="$GPUS" .venv/bin/torchrun --standalone \
-  --nproc_per_node "$WORLD" -m runner.batch_inference pred \
-  -i "$INPUT" -o "$QUAL_DIR/$CASE" --seeds 101 "${COMMON[@]}" \
-  --foldcp_mode distributed --foldcp_size_dp 1 --foldcp_size_cp "$WORLD"
-
-# Matched two-record reference and D2 run.
-TWO_INPUT="$QUAL_DIR/two_records.json"
-CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m runner.batch_inference pred \
-  -i "$TWO_INPUT" -o "$QUAL_DIR/two_serial" --seeds 101,102,103,104 \
-  "${COMMON[@]}"
-CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone \
-  --nproc_per_node 2 -m runner.batch_inference pred \
-  -i "$TWO_INPUT" -o "$QUAL_DIR/two_dp2" --seeds 101,102,103,104 \
-  "${COMMON[@]}" \
-  --foldcp_mode single --foldcp_size_dp 2 --foldcp_size_cp 1
-
-# Rejected hybrid and mismatched-world-size launches.
-CUDA_VISIBLE_DEVICES=0,1,2,3 .venv/bin/torchrun --standalone \
-  --nproc_per_node 4 -m runner.batch_inference pred \
-  -i "$INPUT" -o "$QUAL_DIR/hybrid_guard" --seeds 101,102,103,104 \
-  "${COMMON[@]}" \
-  --foldcp_mode distributed --foldcp_size_dp 2 --foldcp_size_cp 2
-CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone \
-  --nproc_per_node 2 -m runner.batch_inference pred \
-  -i "$INPUT" -o "$QUAL_DIR/world_guard" --seeds 101,102,103,104 \
-  "${COMMON[@]}" \
-  --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
-```
-
-The two-record input was a temporary copy of the checked-in 40-residue record
-with names `foldcp_demo_first` and `foldcp_demo_second`. It was run serially and
-with `D=2` using seeds 101-104. The guard commands used the distributed template
-with `(WORLD,D,P)=(4,2,2)` and the seed-parallel template with `(2,4,1)`.
-Every command had a 900-second timeout and a 200 ms `nvidia-smi` memory trace.
-For each `WORLD=N` row, `GPUS` was `0,...,N-1`; `CASE` and `SEEDS` match the
-matrix entries.
-
-### Four-GPU matrix
-
-Peak memory lists selected physical GPUs in local-rank order. Elapsed time is
-end to end and is diagnostic only on this heterogeneous host.
-
-| Case | World | `D` | `P` | Seeds | Result | Elapsed (s) | Peak MiB |
-| --- | ---: | ---: | ---: | --- | --- | ---: | --- |
-| Serial reference | 1 | 1 | 1 | 101-106 | Pass (0) | 21.147 | 5722 |
-| Seed parallel D2 | 2 | 2 | 1 | 101-106 | Pass (0) | 20.461 | 5888 / 5888 |
-| Seed parallel D3 | 3 | 3 | 1 | 101-106 | Pass (0) | 20.595 | 5876 / 5876 / 5876 |
-| Seed parallel D4 | 4 | 4 | 1 | 101-104 | Pass (0) | 19.414 | 5876 / 5876 / 5876 / 6046 |
-| Two-record serial | 1 | 1 | 1 | 101-104 | Pass (0) | 21.718 | 5722 |
-| Two-record D2 | 2 | 2 | 1 | 101-104 | Pass (0) | 20.091 | 5888 / 5888 |
-| Fold-CP P2 | 2 | 1 | 2 | 101 | Pass (0) | 23.085 | 5888 / 5888 |
-| Fold-CP P3 | 3 | 1 | 3 | 101 | Pass (0) | 23.569 | 5876 / 5876 / 5876 |
-| Fold-CP P4 | 4 | 1 | 4 | 101 | Pass (0) | 24.184 | 5876 / 5876 / 5876 / 6046 |
-| Hybrid guard | 4 | 2 | 2 | 101-104 | Expected fail (1) | 4.895 | 1 / 1 / 1 / 1 |
-| World-size guard | 2 | 4 | 1 | 101-104 | Expected fail (1) | 4.947 | 1 / 1 |
-
-Both guards failed without `Loading from`, wrote no prediction CIF, and exited
-without a timeout or lingering worker. Successful cases produced exactly one
-CIF, summary-confidence JSON, and full-data JSON per expected `(job, seed)`.
-
-### Numerical alignment
-
-Every CIF had the same atom-site schema and exact atom identity/order as its
-matched serial result (335 atoms), and all CIF/full-data/summary numeric values
-were finite. Coordinates and every numeric summary-confidence leaf were checked
-with `numpy.testing.assert_allclose(atol=5e-4, rtol=5e-4)`:
-
-| Candidate | Compared `(job, seed)` pairs | Max coordinate abs delta | Max B-factor abs delta | Max summary abs delta |
-| --- | ---: | ---: | ---: | ---: |
-| D2 | 6 | 0 | 0 | 0 |
-| D3 | 6 | 0 | 0 | 0 |
-| D4 | 4 | 0.001 | 0.02 | 0.0000991821 |
-| Fold-CP P2 | 1 | 0.001 | 0.03 | 0.0003738403 |
-| Fold-CP P3 | 1 | 0.001 | 0.03 | 0.0003738403 |
-| Fold-CP P4 | 1 | 0.001 | 0.03 | 0.0012588501 |
-| Two-record D2 | 8 | 0 | 0 | 0 |
-
-All comparisons passed the stated absolute/relative tolerance. D4's nonzero
-deltas were confined to seed 104 on rank 3 (the RTX 4090); seeds 101-103 on the
-three RTX 3090 ranks had zero recorded deltas. Fold-CP's small deltas were also
-present on homogeneous RTX 3090 P2/P3 runs and are attributable to its changed
-parallel reduction order plus CIF decimal serialization. No seed, sample, atom,
-or schema divergence occurred.
+Append final commands and results here only after the implementation commit has
+passed the automated checks and local matrix. Prior `D x 1` results measured
+rank sharding with scalar per-seed model calls and are not evidence for
+same-GPU batching.
 
 ## Complexity inventory
 
-- New CLI flags or config keys: none.
-- New model, kernel, output, or input paths: none.
-- New dependencies, services, scripts, or abstractions: none.
-- Required code owners changed: existing config, runner, and inference sampler
-  only.
+- New public control: one inference config/CLI integer, `seed_batch_size`.
+- New distributed topology: none.
+- New output or input schema: none.
+- New dependency, service, launcher, or deployment path: none.
+- Model changes: only the normal-path leading seed dimension and per-seed RNG
+  support required by true batching.
 
 ## Non-goals
 
-The SPEC non-goals are binding, especially same-GPU seed batching, hybrid
-`D x P`, model changes, automatic sizing/retry, and Predictify integration.
+The SPEC non-goals are binding, especially batched Fold-CP, hybrid `D x P`,
+automatic sizing/retry, and Predictify integration.

--- a/docs/seed_parallel_inference_spec.md
+++ b/docs/seed_parallel_inference_spec.md
@@ -1,0 +1,185 @@
+# Seed-Parallel Inference Specification
+
+Status: Implemented
+Date: 2026-08-25
+
+This specification adds seed-level data parallelism to the existing inference
+runner without changing model computation, seed meaning, output files, or the
+current `1 x P` Fold-CP path.
+
+## Goal
+
+Allow explicit inference seeds to run concurrently on separate GPUs under
+`torchrun`. Reuse the existing `--foldcp_size_dp` and `--foldcp_size_cp`
+topology flags rather than adding another parallelism interface.
+
+This version supports single-node `torchrun --standalone`; all ranks share the
+same checkout, runtime assets, input paths, and output filesystem.
+
+The default `D=1, P=1` execution must remain the existing serial path, where:
+
+- `D` is `--foldcp_size_dp`, the number of independent seed lanes; and
+- `P` is `--foldcp_size_cp`, the number of Fold-CP ranks used by one seed.
+
+## Public interface
+
+No new CLI flag, config key, input field, or output field is added.
+
+Seed-parallel inference uses the existing single-card model path with one
+process per GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+torchrun --standalone --nproc_per_node 4 \
+  -m runner.batch_inference pred \
+  -i input.json -o output_dp4 -n opendde_v1 \
+  --seeds 101,102,103,104 \
+  --use_msa false --use_template false --use_rna_msa false \
+  --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
+```
+
+`--foldcp_mode single` means that each seed lane uses the normal single-card
+model path. It does not require `WORLD_SIZE=1` when `D > 1`.
+
+## Supported topologies
+
+`WORLD_SIZE` must equal `D * P`.
+
+| Mode | `D` | `P` | Behavior |
+| --- | ---: | ---: | --- |
+| Serial | 1 | 1 | Existing single-process inference |
+| Seed parallel | >1 | 1 | One independent seed lane per GPU |
+| Fold-CP | 1 | >1 | Existing `1 x P` context-parallel inference |
+| Hybrid | >1 | >1 | Rejected in this version |
+
+Hybrid seed parallelism plus Fold-CP is out of scope because current model and
+output ownership are global-rank-oriented. Supporting it would require changes
+inside the Fold-CP model/process-mesh path and would make this PR materially
+larger.
+
+## Execution semantics
+
+Seed precedence remains unchanged: command-line `--seeds`, then the input
+job's `modelSeeds`, then one generated seed.
+
+For seed-parallel `D x 1` execution:
+
+1. For each preprocessed input JSON, rank 0 resolves and validates the ordered
+   seed list once and shares it with all ranks. Existing precedence and the
+   first top-level record's `modelSeeds` behavior remain unchanged.
+2. Seeds must be unique and their count must be at least `D`; invalid requests
+   fail before model inference.
+3. Rank `r` receives `seeds[r::D]`. Every requested seed is assigned exactly
+   once and order is stable within each lane.
+4. Every rank consumes every input job in the same deterministic order. Input
+   records are not sharded by `DistributedSampler`.
+5. Shared input preprocessing runs once on rank 0 and shares the resulting path
+   or failure with all ranks. A preprocessing or seed-validation failure
+   terminates every rank and returns a nonzero command result; existing
+   per-job prediction-error handling remains unchanged.
+6. Each rank retains the existing per-seed sequence: seed global RNG state,
+   featurize, run the model, rank samples, and dump results.
+7. Each rank writes only its assigned seed directories.
+
+For existing `1 x P` Fold-CP execution, all ranks continue to consume the same
+jobs and seeds, and global rank 0 remains the only output writer. No model,
+kernel, checkpoint, or numerical path changes are required for seed parallelism.
+
+Directory inputs must be sorted before distributed iteration so every rank
+processes files in the same order.
+
+## Output and determinism contract
+
+The output layout remains:
+
+```text
+<out_dir>/<job_name>/seed_<seed>/predictions/
+```
+
+Seed-parallel width is an execution setting only. It must not change:
+
+- seed precedence or seed values;
+- `--sample` cardinality within each seed;
+- output filenames, schemas, ranking, or atom ordering; or
+- the result associated with a `(job, seed, sample)` tuple.
+
+Completion and log ordering may differ because lanes finish independently.
+The implementation must log the global rank and assigned seeds sufficiently to
+audit ownership. It must not claim a performance gain without a controlled
+benchmark.
+
+## Validation and errors
+
+Configuration must fail before model loading when:
+
+- `WORLD_SIZE != D * P`;
+- `D > 1` and `P > 1`;
+- `--foldcp_mode distributed` does not have `D=1, P>1`;
+- `--foldcp_mode single` does not have `P=1`.
+
+After each input's seeds are resolved, but before its first model forward, the
+command must fail when seed-parallel execution receives duplicate seeds or
+fewer seeds than lanes.
+
+Errors must identify the conflicting values and the supported topology. A
+request must never silently fall back to serial execution or silently drop,
+duplicate, or overwrite a seed.
+
+## Documentation requirements
+
+The implementation PR must update only the existing public owners:
+
+- `README.md` with one concise seed-parallel example;
+- `docs/inference_instructions.md` with topology and flag semantics;
+- `docs/foldcp_e2e_baseline.md` with reproducible `D x 1`, `1 x P`, and invalid
+  hybrid validation commands; and
+- `CHANGELOG.md` under `[Unreleased]`.
+
+Do not add a second run guide or rename the Fold-CP guide.
+
+## Test requirements
+
+Automated tests must cover:
+
+- supported and rejected topology validation;
+- exact world-size validation before model loading;
+- rank-to-seed assignment, including uneven tails;
+- rank-0 seed resolution and preprocessing propagation;
+- multi-record inputs appearing in the same order on every rank;
+- exactly-once `(job, seed)` execution and output ownership;
+- unchanged serial `D=1, P=1` behavior; and
+- unchanged existing `1 x P` Fold-CP behavior.
+
+The implementation must also be qualified locally on the available four-GPU
+host using world sizes 1, 2, 3, and 4. The matrix must include serial,
+seed-parallel, Fold-CP, mismatched-world-size, and rejected-hybrid cases. Use the
+same small checked-in input, released checkpoint, seeds, dtype, kernels, cycle,
+step, and sample settings for matched comparisons.
+
+For successful runs, verify seed directories, sample counts, CIF schema, atom
+ordering, finite values, coordinates, and summary-confidence outputs against
+the matching serial result with an explicit dtype-appropriate tolerance. Record
+the exact commit, commands, environment, GPU mapping, raw timing, peak memory,
+and numerical deltas. The heterogeneous four-GPU host provides correctness
+evidence only, not a portable speed claim.
+
+## Non-goals
+
+- Same-GPU tensor batching of multiple seeds.
+- Hybrid `D x P` execution with both dimensions greater than one.
+- Automatic batch sizing, OOM retries, scheduling, or performance policy.
+- Changes to `N_sample`, checkpoints, kernels, model code, output schemas, or
+  input JSON.
+- Predictify, Cloud runner, container, or deployment changes.
+- Multi-node execution or filesystems that are not shared by all local ranks.
+
+## Acceptance criteria
+
+- The supported topology table is enforced exactly.
+- Every requested `(job, seed)` runs and is written exactly once.
+- Serial and existing Fold-CP behavior remain compatible.
+- Focused tests and the non-network test suite pass.
+- The complete local world-size 1-4 GPU matrix exits without hangs and records
+  numerical-alignment evidence.
+- Documentation and CLI help describe the implemented behavior consistently.
+- The implementation diff contains no unrelated refactor or new abstraction.

--- a/docs/seed_parallel_inference_spec.md
+++ b/docs/seed_parallel_inference_spec.md
@@ -1,94 +1,132 @@
 # Seed-Parallel Inference Specification
 
-Status: Implemented
-Date: 2026-08-25
+Status: Implementation and qualification in progress
+Date: 2026-08-26
 
-This specification adds seed-level data parallelism to the existing inference
-runner without changing model computation, seed meaning, output files, or the
-current `1 x P` Fold-CP path.
+This specification adds tensor-batched seed inference on one GPU and composes
+it with the existing multi-GPU seed sharding. Single- and multi-GPU execution
+use the same rank-local seed-batch path; additional GPUs only change which
+seeds each rank owns.
 
 ## Goal
 
-Allow explicit inference seeds to run concurrently on separate GPUs under
-`torchrun`. Reuse the existing `--foldcp_size_dp` and `--foldcp_size_cp`
-topology flags rather than adding another parallelism interface.
+Run independent inference seeds concurrently within one model forward while
+preserving each seed's features, random stream, samples, and output files.
 
-This version supports single-node `torchrun --standalone`; all ranks share the
-same checkout, runtime assets, input paths, and output filesystem.
+Reuse the existing Fold-CP topology flags for process placement and add one
+orthogonal batch-width control:
 
-The default `D=1, P=1` execution must remain the existing serial path, where:
+- `D` is `--foldcp_size_dp`, the number of seed-sharding ranks;
+- `P` is `--foldcp_size_cp`, the number of Fold-CP ranks cooperating on one
+  model execution; and
+- `B` is `--seed_batch_size`, the maximum number of seeds in one rank-local
+  model batch.
 
-- `D` is `--foldcp_size_dp`, the number of independent seed lanes; and
-- `P` is `--foldcp_size_cp`, the number of Fold-CP ranks used by one seed.
+`B` defaults to `1`, so existing commands retain their prior memory profile.
+It does not change `WORLD_SIZE` or `--sample` (`N_sample`).
 
 ## Public interface
 
-No new CLI flag, config key, input field, or output field is added.
+The new CLI/config option is:
 
-Seed-parallel inference uses the existing single-card model path with one
-process per GPU:
+```text
+--seed_batch_size INTEGER  Maximum seeds per rank-local model batch. [default: 1]
+```
+
+For example, two seeds can share one GPU:
+
+```bash
+opendde pred \
+  -i input.json -o output_b2 -n opendde_v1 \
+  --seeds 101,102 \
+  --seed_batch_size 2
+```
+
+The same option composes with multi-GPU seed sharding. This command assigns
+two seeds to each of four ranks:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3 \
 torchrun --standalone --nproc_per_node 4 \
   -m runner.batch_inference pred \
-  -i input.json -o output_dp4 -n opendde_v1 \
-  --seeds 101,102,103,104 \
-  --use_msa false --use_template false --use_rna_msa false \
+  -i input.json -o output_d4_b2 -n opendde_v1 \
+  --seeds 101,102,103,104,105,106,107,108 \
+  --seed_batch_size 2 \
   --foldcp_mode single --foldcp_size_dp 4 --foldcp_size_cp 1
 ```
 
-`--foldcp_mode single` means that each seed lane uses the normal single-card
-model path. It does not require `WORLD_SIZE=1` when `D > 1`.
-
-## Supported topologies
+## Supported execution modes
 
 `WORLD_SIZE` must equal `D * P`.
 
-| Mode | `D` | `P` | Behavior |
-| --- | ---: | ---: | --- |
-| Serial | 1 | 1 | Existing single-process inference |
-| Seed parallel | >1 | 1 | One independent seed lane per GPU |
-| Fold-CP | 1 | >1 | Existing `1 x P` context-parallel inference |
-| Hybrid | >1 | >1 | Rejected in this version |
+| Mode | `D` | `P` | `B` | Behavior |
+| --- | ---: | ---: | ---: | --- |
+| Scalar single GPU | 1 | 1 | 1 | One seed per model call |
+| Batched single GPU | 1 | 1 | >1 | Up to `B` seeds per model call |
+| Sharded seed batches | >1 | 1 | >=1 | Rank-local batches after seed sharding |
+| Fold-CP | 1 | >1 | 1 | Existing context-parallel inference |
+| Batched Fold-CP | any | >1 | >1 | Rejected |
+| Hybrid `D x P` | >1 | >1 | any | Rejected |
 
-Hybrid seed parallelism plus Fold-CP is out of scope because current model and
-output ownership are global-rank-oriented. Supporting it would require changes
-inside the Fold-CP model/process-mesh path and would make this PR materially
-larger.
+`--foldcp_mode single` selects the normal model path for both one and multiple
+seed-sharding ranks. Same-GPU batching requires `P=1`; this version does not add
+a seed batch dimension to Fold-CP.
 
-## Execution semantics
+## Scheduling semantics
 
 Seed precedence remains unchanged: command-line `--seeds`, then the input
 job's `modelSeeds`, then one generated seed.
 
-For seed-parallel `D x 1` execution:
+For each preprocessed input:
 
-1. For each preprocessed input JSON, rank 0 resolves and validates the ordered
-   seed list once and shares it with all ranks. Existing precedence and the
-   first top-level record's `modelSeeds` behavior remain unchanged.
-2. Seeds must be unique and their count must be at least `D`; invalid requests
-   fail before model inference.
-3. Rank `r` receives `seeds[r::D]`. Every requested seed is assigned exactly
-   once and order is stable within each lane.
-4. Every rank consumes every input job in the same deterministic order. Input
-   records are not sharded by `DistributedSampler`.
-5. Shared input preprocessing runs once on rank 0 and shares the resulting path
-   or failure with all ranks. A preprocessing or seed-validation failure
-   terminates every rank and returns a nonzero command result; existing
-   per-job prediction-error handling remains unchanged.
-6. Each rank retains the existing per-seed sequence: seed global RNG state,
-   featurize, run the model, rank samples, and dump results.
-7. Each rank writes only its assigned seed directories.
+1. Resolve the ordered seed list once and share it with all ranks.
+2. Rank `r` receives `seeds[r::D]`.
+3. Each rank partitions that ordered slice into consecutive chunks of at most
+   `B` seeds.
+4. Every chunk, including a smaller final chunk, follows the same rank-local
+   feature, model, postprocessing, and output path.
+5. Every requested seed is assigned exactly once. Multiple ranks change only
+   ownership, not the batching implementation.
 
-For existing `1 x P` Fold-CP execution, all ranks continue to consume the same
-jobs and seeds, and global rank 0 remains the only output writer. No model,
-kernel, checkpoint, or numerical path changes are required for seed parallelism.
+For example, with seeds `101-107`, `D=2`, and `B=2`:
 
-Directory inputs must be sorted before distributed iteration so every rank
-processes files in the same order.
+```text
+rank 0: [101, 103], [105, 107]
+rank 1: [102, 104], [106]
+```
 
-## Output and determinism contract
+Every rank enumerates and consumes input jobs in the same deterministic order.
+In a multi-rank run, rank 0 preprocesses each input once and broadcasts the
+resulting shared path or failure; single-process preprocessing remains local.
+Each rank writes only its assigned seed directories.
+
+## Model and random-stream contract
+
+Seed-dependent features are constructed independently and stacked on a leading
+seed dimension. The normal model path carries tensors shaped conceptually as:
+
+```text
+[B_seed, N_sample, ...]
+```
+
+`B_seed` is the current rank-local chunk size and may be smaller than the
+configured `B`. `N_sample` remains the number of diffusion samples within each
+seed; seed batching does not reinterpret or replace it.
+
+MSA sampling, reference-position augmentation, and diffusion noise must retain
+independent per-seed random streams. Training-Free Guidance with `B>1` is
+rejected. Scalar postprocessing and dumping split the leading seed dimension and
+continue to receive one seed at a time, preserving existing output schemas and
+ranking behavior.
+
+Per-seed random draws must not depend on the other seeds in a batch. End-to-end
+predictions are not required to be bitwise identical across batch widths:
+batch-shaped kernels can use different floating-point launch geometry, and
+small BF16 differences can amplify through iterative diffusion. Qualification
+must report those numerical deltas rather than treating them as RNG-stream
+mixing.
+
+## Output and compatibility contract
 
 The output layout remains:
 
@@ -96,43 +134,46 @@ The output layout remains:
 <out_dir>/<job_name>/seed_<seed>/predictions/
 ```
 
-Seed-parallel width is an execution setting only. It must not change:
+Changing `D` or `B` must not change:
 
-- seed precedence or seed values;
-- `--sample` cardinality within each seed;
+- seed precedence or values;
+- `--sample` cardinality within a seed;
 - output filenames, schemas, ranking, or atom ordering; or
-- the result associated with a `(job, seed, sample)` tuple.
+- the independent random stream associated with a `(job, seed, sample)` tuple.
 
-Completion and log ordering may differ because lanes finish independently.
-The implementation must log the global rank and assigned seeds sufficiently to
-audit ownership. It must not claim a performance gain without a controlled
-benchmark.
+Completion and log ordering may differ. Logs must identify rank ownership and
+the seeds in each batch sufficiently to audit execution.
 
 ## Validation and errors
 
-Configuration must fail before model loading when:
+Configuration must fail before model inference when:
 
+- `B < 1`;
 - `WORLD_SIZE != D * P`;
 - `D > 1` and `P > 1`;
-- `--foldcp_mode distributed` does not have `D=1, P>1`;
+- `B > 1` and `P > 1`;
+- `B > 1` and inference data loading uses `num_workers != 0`;
+- `B > 1` and `model.N_model_seed != 1`;
+- `B > 1` and Training-Free Guidance is enabled;
+- `--foldcp_mode distributed` does not have `D=1, P>1`; or
 - `--foldcp_mode single` does not have `P=1`.
 
-After each input's seeds are resolved, but before its first model forward, the
-command must fail when seed-parallel execution receives duplicate seeds or
-fewer seeds than lanes.
+Seeds must be unique when either `D > 1` or `B > 1`. A multi-rank request must
+contain at least `D` seeds. Errors must identify the conflicting values and
+must never silently drop, duplicate, or overwrite a seed.
 
-Errors must identify the conflicting values and the supported topology. A
-request must never silently fall back to serial execution or silently drop,
-duplicate, or overwrite a seed.
+The runner must not catch a CUDA OOM and silently reduce `B`, retry seeds one at
+a time, or select a batch size automatically. Users choose a width that fits
+their input and device.
 
 ## Documentation requirements
 
-The implementation PR must update only the existing public owners:
+The implementation PR updates the existing public owners:
 
-- `README.md` with one concise seed-parallel example;
-- `docs/inference_instructions.md` with topology and flag semantics;
-- `docs/foldcp_e2e_baseline.md` with reproducible `D x 1`, `1 x P`, and invalid
-  hybrid validation commands; and
+- `README.md` with concise single- and multi-GPU examples;
+- `docs/inference_instructions.md` with `D`, `P`, and `B` semantics;
+- `docs/foldcp_e2e_baseline.md` with reproducible comparison and guard commands;
+  and
 - `CHANGELOG.md` under `[Unreleased]`.
 
 Do not add a second run guide or rename the Fold-CP guide.
@@ -141,45 +182,41 @@ Do not add a second run guide or rename the Fold-CP guide.
 
 Automated tests must cover:
 
-- supported and rejected topology validation;
-- exact world-size validation before model loading;
-- rank-to-seed assignment, including uneven tails;
-- rank-0 seed resolution and preprocessing propagation;
-- multi-record inputs appearing in the same order on every rank;
-- exactly-once `(job, seed)` execution and output ownership;
-- unchanged serial `D=1, P=1` behavior; and
-- unchanged existing `1 x P` Fold-CP behavior.
+- `B` validation and CLI/config propagation;
+- exact rank-to-seed assignment followed by batching, including uneven tails;
+- supported and rejected `D`, `P`, `B`, and world-size combinations;
+- independent, persistent per-seed random streams;
+- batched feature and model tensor shapes with `N_sample > 1`;
+- scalar-versus-batched random-stream and small-model-stage equivalence for
+  individual seeds;
+- per-seed postprocessing and exactly-once output ownership;
+- unchanged `B=1` single- and multi-rank behavior; and
+- unchanged existing `1 x P`, `B=1` Fold-CP behavior.
 
-The implementation must also be qualified locally on the available four-GPU
-host using world sizes 1, 2, 3, and 4. The matrix must include serial,
-seed-parallel, Fold-CP, mismatched-world-size, and rejected-hybrid cases. Use the
-same small checked-in input, released checkpoint, seeds, dtype, kernels, cycle,
-step, and sample settings for matched comparisons.
-
-For successful runs, verify seed directories, sample counts, CIF schema, atom
-ordering, finite values, coordinates, and summary-confidence outputs against
-the matching serial result with an explicit dtype-appropriate tolerance. Record
-the exact commit, commands, environment, GPU mapping, raw timing, peak memory,
-and numerical deltas. The heterogeneous four-GPU host provides correctness
-evidence only, not a portable speed claim.
+Qualification must exercise world sizes 1, 2, 3, and 4, scalar and batched
+single-GPU execution, batched multi-GPU seed sharding, a partial final batch,
+Fold-CP with `B=1`, and every new guard. Successful comparisons must record the
+exact commit, command, GPU mapping, dtype, timing, peak GPU memory, output
+cardinality, and numerical deltas from matching scalar runs.
 
 ## Non-goals
 
-- Same-GPU tensor batching of multiple seeds.
+- Seed batching combined with Fold-CP (`P > 1`).
 - Hybrid `D x P` execution with both dimensions greater than one.
-- Automatic batch sizing, OOM retries, scheduling, or performance policy.
-- Changes to `N_sample`, checkpoints, kernels, model code, output schemas, or
-  input JSON.
+- Automatic batch sizing, OOM retries, or performance policy.
+- Changes to checkpoint or input/output schemas.
 - Predictify, Cloud runner, container, or deployment changes.
-- Multi-node execution or filesystems that are not shared by all local ranks.
+- Multi-node execution or filesystems not shared by all ranks.
 
 ## Acceptance criteria
 
-- The supported topology table is enforced exactly.
+- Single- and multi-GPU seed execution share one rank-local batch path.
 - Every requested `(job, seed)` runs and is written exactly once.
-- Serial and existing Fold-CP behavior remain compatible.
-- Focused tests and the non-network test suite pass.
-- The complete local world-size 1-4 GPU matrix exits without hangs and records
-  numerical-alignment evidence.
+- Per-seed random streams remain aligned when placed in a batch; BF16
+  end-to-end deltas are recorded explicitly.
+- `N_sample` remains independent of seed batch width.
+- Existing `B=1` and Fold-CP behavior remain compatible.
+- Focused tests and the non-network suite pass.
+- The local one-to-four-GPU matrix exits without hangs and records timing,
+  memory, output, and numerical-alignment evidence.
 - Documentation and CLI help describe the implemented behavior consistently.
-- The implementation diff contains no unrelated refactor or new abstraction.

--- a/docs/seed_parallel_inference_spec.md
+++ b/docs/seed_parallel_inference_spec.md
@@ -1,6 +1,6 @@
 # Seed-Parallel Inference Specification
 
-Status: Implementation and qualification in progress
+Status: Implemented and locally qualified
 Date: 2026-08-26
 
 This specification adds tensor-batched seed inference on one GPU and composes

--- a/opendde/config/inference_defaults.py
+++ b/opendde/config/inference_defaults.py
@@ -13,6 +13,7 @@ inference_configs: dict[str, Any] = {
     "model_name": DEFAULT_MODEL_NAME,  # inference model selection
     # Empty = "unset"; resolved at run time to CLI > JSON modelSeeds > random seed.
     "seeds": ListValue([], dtype=int),
+    "seed_batch_size": 1,
     "dump_dir": "./output",
     "need_atom_confidence": True,
     "sorted_by_ranking_score": True,

--- a/opendde/config/schema.py
+++ b/opendde/config/schema.py
@@ -344,6 +344,7 @@ class OpenDDEConfig(BaseConfig):
     # inference defaults / runtime selections
     model_name: str
     seeds: list[int]
+    seed_batch_size: int = 1
     dump_dir: str
     need_atom_confidence: bool
     sorted_by_ranking_score: bool

--- a/opendde/data/inference/infer_dataloader.py
+++ b/opendde/data/inference/infer_dataloader.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 import torch
 from biotite.structure import AtomArray
-from torch.utils.data import DataLoader, Dataset, DistributedSampler
+from torch.utils.data import DataLoader, Dataset
 
 from opendde.data.core import ccd
 from opendde.data.inference.json_to_feature import SampleDictToFeatures
@@ -18,7 +18,6 @@ from opendde.data.msa.msa_featurizer import InferenceMSAFeaturizer
 from opendde.data.template.template_featurizer import InferenceTemplateFeaturizer
 from opendde.data.template.template_utils import TemplateHitFeaturizer
 from opendde.data.utils import data_type_transform, make_dummy_feature
-from opendde.utils.distributed import DIST_WRAPPER
 from opendde.utils.torch_utils import collate_fn_identity, dict_to_tensor
 
 logger = logging.getLogger(__name__)
@@ -39,16 +38,10 @@ def get_inference_dataloader(configs: Any) -> DataLoader:
     inference_dataset = InferenceDataset(
         configs=configs,
     )
-    sampler = DistributedSampler(
-        dataset=inference_dataset,
-        num_replicas=DIST_WRAPPER.world_size,
-        rank=DIST_WRAPPER.rank,
-        shuffle=False,
-    )
     dataloader = DataLoader(
         dataset=inference_dataset,
         batch_size=1,
-        sampler=sampler,
+        shuffle=False,
         collate_fn=collate_fn_identity,
         num_workers=configs.num_workers,
     )

--- a/opendde/distributed/foldcp/config.py
+++ b/opendde/distributed/foldcp/config.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Aureka AI Research
-"""Runtime flags for single-process or multi-GPU 1 x P Fold-CP inference."""
+"""Runtime flags for serial, seed-parallel, or 1 x P Fold-CP inference."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def _as_int(value: Any, default: int) -> int:
 
 @dataclass(frozen=True)
 class FoldCPConfig:
-    """Validated Fold-CP launch configuration."""
+    """Validated inference topology configuration."""
 
     mode: FoldCPMode = "single"
     size_dp: int = 1
@@ -69,9 +69,17 @@ class FoldCPConfig:
             raise ValueError("foldcp_size_dp must be >= 1.")
         if self.size_cp < 1:
             raise ValueError("foldcp_size_cp must be >= 1.")
+        if self.size_dp > 1 and self.size_cp > 1:
+            raise ValueError(
+                "Hybrid seed-parallel and Fold-CP inference is not supported: "
+                f"foldcp_size_dp={self.size_dp}, foldcp_size_cp={self.size_cp}. "
+                "Use P = 1 or D = 1."
+            )
         if self.mode == "single" and self.size_cp != 1:
             raise ValueError("foldcp_mode='single' requires foldcp_size_cp=1.")
         if self.mode == "distributed":
+            if self.size_dp != 1:
+                raise ValueError("foldcp_mode='distributed' requires foldcp_size_dp=1.")
             if self.size_cp == 1:
                 raise ValueError(
                     "foldcp_mode='distributed' requires foldcp_size_cp > 1."
@@ -101,6 +109,12 @@ class FoldCPConfig:
                 f"torchrun --nproc_per_node {nproc} -m runner.batch_inference pred "
                 f"--foldcp_mode distributed --foldcp_size_dp {self.size_dp} "
                 f"--foldcp_size_cp {self.size_cp}"
+            )
+        if self.size_dp > 1:
+            return (
+                f"torchrun --standalone --nproc_per_node {self.size_dp} "
+                "-m runner.batch_inference pred --foldcp_mode single "
+                f"--foldcp_size_dp {self.size_dp} --foldcp_size_cp 1"
             )
         return (
             "python -m runner.batch_inference pred "

--- a/opendde/model/generator.py
+++ b/opendde/model/generator.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Aureka AI Research
+from collections.abc import Sequence
 from typing import Any, Callable, Optional
 
 import numpy as np
@@ -8,6 +9,7 @@ import torch
 from opendde.model.utils import centre_random_augmentation
 from opendde.tfg import TFGEngine, parse_tfg_config
 from opendde.utils.logger import get_logger
+from opendde.utils.random import TorchGenerator, randn_with_generators
 
 logger = get_logger(__name__)
 
@@ -89,7 +91,7 @@ def sample_diffusion(
     inplace_safe: bool = False,
     attn_chunk_size: Optional[int] = None,
     enable_efficient_fusion: bool = False,
-    rollout_seed: Optional[int] = None,
+    rollout_seed: Optional[int | Sequence[int] | torch.Tensor] = None,
     guidance_configs: Optional[dict[str, Any]] = None,
     pair_z_spec: Any = None,
     atom_window_spec: Any = None,
@@ -136,13 +138,40 @@ def sample_diffusion(
     batch_shape = s_inputs.shape[:-2]
     device = s_inputs.device
     dtype = s_inputs.dtype
-    torch_generator = None
-    numpy_rng = None
+    torch_generator: TorchGenerator = None
+    numpy_rng: Optional[np.random.Generator | tuple[np.random.Generator, ...]] = None
     if rollout_seed is not None:
-        torch_generator = torch.Generator(device=device)
-        torch_generator.manual_seed(int(rollout_seed))
-        numpy_rng = np.random.default_rng(int(rollout_seed))
+        if isinstance(rollout_seed, torch.Tensor):
+            if rollout_seed.ndim == 0:
+                rollout_seeds = [int(rollout_seed.detach().cpu().item())]
+            else:
+                rollout_seeds = [
+                    int(seed) for seed in rollout_seed.detach().cpu().tolist()
+                ]
+        elif isinstance(rollout_seed, Sequence):
+            rollout_seeds = [int(seed) for seed in rollout_seed]
+        else:
+            rollout_seeds = [int(rollout_seed)]
+
+        if len(rollout_seeds) == 1 and not batch_shape:
+            torch_generator = torch.Generator(device=device).manual_seed(
+                rollout_seeds[0]
+            )
+            numpy_rng = np.random.default_rng(rollout_seeds[0])
+        else:
+            if batch_shape != (len(rollout_seeds),):
+                raise ValueError(
+                    "Seed-batched diffusion requires one leading batch dimension; "
+                    f"got batch_shape={batch_shape} for {len(rollout_seeds)} seeds."
+                )
+            torch_generator = tuple(
+                torch.Generator(device=device).manual_seed(seed)
+                for seed in rollout_seeds
+            )
+            numpy_rng = tuple(np.random.default_rng(seed) for seed in rollout_seeds)
     tfg_cfg = parse_tfg_config(guidance_configs)
+    if tfg_cfg.enable and isinstance(torch_generator, Sequence):
+        raise ValueError("Training-Free Guidance does not support seed batching.")
     if tfg_cfg.enable:
         logger.info("Training-free guidance is enabled.")
         tfg = TFGEngine(tfg_cfg, device=device, dtype=dtype)
@@ -152,8 +181,8 @@ def sample_diffusion(
     def _chunk_sample_diffusion(chunk_n_sample, inplace_safe):
         # init noise
         # [..., chunk_n_sample, N_atom, 3]
-        x_l = noise_schedule[0] * torch.randn(
-            size=(*batch_shape, chunk_n_sample, N_atom, 3),
+        x_l = noise_schedule[0] * randn_with_generators(
+            (*batch_shape, chunk_n_sample, N_atom, 3),
             device=device,
             dtype=dtype,
             generator=torch_generator,
@@ -163,27 +192,47 @@ def sample_diffusion(
             zip(noise_schedule[:-1], noise_schedule[1:])
         ):
             # [..., chunk_n_sample, N_atom, 3]
-            x_l = (
-                centre_random_augmentation(
-                    x_input_coords=x_l,
-                    N_sample=1,
-                    torch_generator=torch_generator,
-                    numpy_rng=numpy_rng,
+            if isinstance(torch_generator, Sequence):
+                assert isinstance(numpy_rng, tuple)
+                x_l = torch.stack(
+                    [
+                        centre_random_augmentation(
+                            x_input_coords=x_l[lane],
+                            N_sample=1,
+                            torch_generator=lane_generator,
+                            numpy_rng=numpy_rng[lane],
+                        ).squeeze(dim=-3)
+                        for lane, lane_generator in enumerate(torch_generator)
+                    ],
+                    dim=0,
+                ).to(dtype)
+            else:
+                x_l = (
+                    centre_random_augmentation(
+                        x_input_coords=x_l,
+                        N_sample=1,
+                        torch_generator=torch_generator,
+                        numpy_rng=numpy_rng,
+                    )
+                    .squeeze(dim=-3)
+                    .to(dtype)
                 )
-                .squeeze(dim=-3)
-                .to(dtype)
-            )
             # Denoise with a predictor-corrector sampler
             # 1. Add noise to move x_{c_tau_last} to x_{t_hat}
             gamma = float(gamma0) if c_tau > gamma_min else 0
             t_hat = c_tau_last * (gamma + 1)
 
             delta_noise_level = torch.sqrt(t_hat**2 - c_tau_last**2)
-            x_noisy = x_l + noise_scale_lambda * delta_noise_level * torch.randn(
-                size=x_l.shape,
-                device=device,
-                dtype=dtype,
-                generator=torch_generator,
+            x_noisy = (
+                x_l
+                + noise_scale_lambda
+                * delta_noise_level
+                * randn_with_generators(
+                    x_l.shape,
+                    device=device,
+                    dtype=dtype,
+                    generator=torch_generator,
+                )
             )
             # 2. Denoise from x_{t_hat} to x_{c_tau}
             # Euler step only

--- a/opendde/model/modules/diffusion.py
+++ b/opendde/model/modules/diffusion.py
@@ -842,11 +842,10 @@ class DiffusionConditioning(nn.Module):
         z_pair_trunk = z_trunk
         if self.compress_pair_z:
             z_pair_trunk = self._project_z_trunk(z_trunk)
+        relp = self.relpe(relp_feature)
+        relp = relp.expand(*z_pair_trunk.shape[:-1], relp.shape[-1])
         pair_z = torch.cat(
-            tensors=[
-                z_pair_trunk,
-                self.relpe(relp_feature),
-            ],
+            tensors=[z_pair_trunk, relp],
             dim=-1,
         )  # [..., N_tokens, N_tokens, 2*c_z_pair_diffusion]
         pair_z = self._project_pair_z(pair_z)

--- a/opendde/model/modules/pairformer.py
+++ b/opendde/model/modules/pairformer.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Aureka AI Research
 # pylint: disable=C0114
 import os
+from collections.abc import Sequence
 from functools import partial
 from typing import Any, Optional, Union
 
@@ -1625,6 +1626,7 @@ class MSAModule(nn.Module):
         input_feature_dict: dict[str, Any],
         s_inputs: torch.Tensor,
         z_token_dim: int,
+        generators: Optional[Sequence[torch.Generator]] = None,
     ) -> Optional[torch.Tensor]:
         # If n_blocks < 1, return z unchanged.
         if self.n_blocks < 1:
@@ -1640,6 +1642,7 @@ class MSAModule(nn.Module):
             num_msa=self.msa_depth,
             msa_mask=input_feature_dict.get("msa_mask"),
             gap_token=self.input_feature["msa"] - 1,
+            generators=generators,
         )
         # pylint: disable=E1102
         if z_token_dim > 2000:
@@ -1663,7 +1666,7 @@ class MSAModule(nn.Module):
         )
         del msa_feat
         msa_sample = self.linear_no_bias_m(msa_sample)
-        return msa_sample + self.linear_no_bias_s(s_inputs)
+        return msa_sample + self.linear_no_bias_s(s_inputs).unsqueeze(dim=-3)
 
     def forward_foldcp_local_pair(
         self,
@@ -1677,11 +1680,13 @@ class MSAModule(nn.Module):
         triangle_attention: str = "torch",
         inplace_safe: bool = False,
         chunk_size: Optional[int] = None,
+        generators: Optional[Sequence[torch.Generator]] = None,
     ) -> tuple[torch.Tensor, FoldCPPairShardSpec]:
         msa_sample = self._prepare_msa_sample(
             input_feature_dict=input_feature_dict,
             s_inputs=s_inputs,
             z_token_dim=z_spec.original_shape[z_spec.pair_dims[0]],
+            generators=generators,
         )
         if msa_sample is None:
             return z_local.contiguous(), z_spec
@@ -1709,6 +1714,7 @@ class MSAModule(nn.Module):
         triangle_attention: str = "torch",
         inplace_safe: bool = False,
         chunk_size: Optional[int] = None,
+        generators: Optional[Sequence[torch.Generator]] = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -1737,6 +1743,7 @@ class MSAModule(nn.Module):
             input_feature_dict=input_feature_dict,
             s_inputs=s_inputs,
             z_token_dim=z.shape[-2],
+            generators=generators,
         )
         if msa_sample is None:
             return z
@@ -1856,11 +1863,11 @@ class TemplateEmbedder(nn.Module):
             # Compatible with the OpenDDE 0.5.0 model series
             return 0
         asym_id = input_feature_dict["asym_id"]
-        multichain_mask = (asym_id[:, None] == asym_id[None, :]).to(z.dtype)
+        multichain_mask = (asym_id[..., :, None] == asym_id[..., None, :]).to(z.dtype)
 
-        num_residues = z.shape[0]
+        num_residues = z.shape[-2]
         # determine whether the number of templates is the configured maximum value, otherwise error out
-        num_templates = input_feature_dict["template_aatype"].shape[0]
+        num_templates = input_feature_dict["template_aatype"].shape[-2]
         query_num_channels = z.shape[-1]
 
         if pair_mask is None:
@@ -1882,7 +1889,12 @@ class TemplateEmbedder(nn.Module):
             )
         u = u / (1e-7 + num_templates)
         u = self.linear_no_bias_u(self.relu(u))
-        assert u.shape == (num_residues, num_residues, query_num_channels)
+        assert u.shape == (
+            *z.shape[:-3],
+            num_residues,
+            num_residues,
+            query_num_channels,
+        )
         return u
 
     @staticmethod
@@ -2251,10 +2263,10 @@ class TemplateEmbedder(nn.Module):
         to_concat = []
 
         dgram = input_feature_dict["template_distogram"][
-            template_id
-        ]  # [N_token, N_token, 39]
+            ..., template_id, :, :, :
+        ]  # [..., N_token, N_token, 39]
         pseudo_beta_mask_2d = input_feature_dict["template_pseudo_beta_mask"][
-            template_id
+            ..., template_id, :, :
         ]
         dgram = dgram * multichain_mask[..., None] * pair_mask[..., None]
         pseudo_beta_mask_2d = (
@@ -2263,19 +2275,28 @@ class TemplateEmbedder(nn.Module):
         to_concat.append(dgram)
         to_concat.append(pseudo_beta_mask_2d.unsqueeze(-1))
 
-        aatype = input_feature_dict["template_aatype"][template_id]  # [N_token]
+        aatype = input_feature_dict["template_aatype"][
+            ..., template_id, :
+        ]  # [..., N_token]
         aatype = F.one_hot(aatype, num_classes=len(STD_RESIDUES_WITH_GAP))
-        to_concat.append(expand_at_dim(aatype, dim=-3, n=z.shape[0]))
-        to_concat.append(expand_at_dim(aatype, dim=-2, n=z.shape[0]))
+        template_pair_shape = (*dgram.shape[:-1], aatype.shape[-1])
+        to_concat.append(
+            expand_at_dim(aatype, dim=-3, n=z.shape[-2]).expand(template_pair_shape)
+        )
+        to_concat.append(
+            expand_at_dim(aatype, dim=-2, n=z.shape[-2]).expand(template_pair_shape)
+        )
 
-        unit_vector = input_feature_dict["template_unit_vector"][template_id]
+        unit_vector = input_feature_dict["template_unit_vector"][
+            ..., template_id, :, :, :
+        ]
         unit_vector = (
             unit_vector * multichain_mask[..., None] * pair_mask[..., None]
         )  # [N_token, N_token, 3]
         to_concat.append(unit_vector)
 
         backbone_mask_2d = input_feature_dict["template_backbone_frame_mask"][
-            template_id
+            ..., template_id, :, :
         ]
         backbone_mask_2d = backbone_mask_2d * multichain_mask * pair_mask
         to_concat.append(backbone_mask_2d.unsqueeze(-1))

--- a/opendde/model/msa_sampling.py
+++ b/opendde/model/msa_sampling.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Aureka AI Research
+import math
+from collections.abc import Sequence
 from typing import Optional
 
 import torch
@@ -18,6 +20,7 @@ def subsample_msa_feature_dict_valid_first(
     num_msa: int = 1024,
     msa_mask: Optional[torch.Tensor] = None,
     gap_token: Optional[int] = None,
+    generators: Optional[Sequence[torch.Generator]] = None,
 ) -> dict[str, torch.Tensor]:
     """Subsample MSA rows with AF3/OpenFold3-style valid-first priority.
 
@@ -31,6 +34,83 @@ def subsample_msa_feature_dict_valid_first(
     msa_len = msa.size(dim=msa_dim)
     device = msa.device
     num_msa = max(0, min(num_msa, msa_len))
+
+    if generators is not None:
+        batch_shape = msa.shape[: msa_dim % msa.ndim]
+        batch_size = math.prod(batch_shape)
+        if batch_size != len(generators):
+            raise ValueError(
+                "MSA seed batch shape does not match the generator count: "
+                f"batch_shape={tuple(batch_shape)}, generators={len(generators)}."
+            )
+        if msa_dim % msa.ndim != msa.ndim - 2:
+            raise ValueError(
+                "Seed-batched MSA sampling requires the MSA row dim at -2."
+            )
+
+        row_valid = None
+        if msa_mask is not None:
+            row_valid = msa_mask.bool().any(dim=-1).reshape(batch_size, msa_len)
+        if gap_token is not None:
+            token_row_valid = (
+                (msa != gap_token).any(dim=-1).reshape(batch_size, msa_len)
+            )
+            if row_valid is None:
+                row_valid = token_row_valid
+            else:
+                mask_has_no_signal = row_valid.all(dim=-1, keepdim=True)
+                row_valid = torch.where(mask_has_no_signal, token_row_valid, row_valid)
+        if row_valid is None:
+            row_valid = torch.ones(batch_size, msa_len, dtype=torch.bool, device=device)
+
+        batch_indices = []
+        for lane, generator in enumerate(generators):
+            valid_idx = row_valid[lane].nonzero(as_tuple=False).squeeze(-1)
+            invalid_idx = (~row_valid[lane]).nonzero(as_tuple=False).squeeze(-1)
+            selected = []
+            take_valid = min(valid_idx.numel(), num_msa)
+            if take_valid > 0:
+                valid_perm = valid_idx[
+                    torch.randperm(
+                        valid_idx.numel(), device=device, generator=generator
+                    )
+                ]
+                selected.append(valid_perm[:take_valid])
+            take_invalid = num_msa - take_valid
+            if take_invalid > 0 and invalid_idx.numel() > 0:
+                invalid_perm = invalid_idx[
+                    torch.randperm(
+                        invalid_idx.numel(), device=device, generator=generator
+                    )
+                ]
+                selected.append(invalid_perm[:take_invalid])
+            batch_indices.append(
+                torch.cat(selected, dim=0)
+                if selected
+                else torch.empty(0, dtype=torch.long, device=device)
+            )
+        indices = torch.stack(batch_indices, dim=0)
+
+        def gather_seed_batch(value: torch.Tensor, dim: int) -> torch.Tensor:
+            normalized_dim = dim % value.ndim
+            flat_value = value.reshape(batch_size, *value.shape[len(batch_shape) :])
+            flat_dim = normalized_dim - len(batch_shape) + 1
+            index_shape = [batch_size] + [1] * (flat_value.ndim - 1)
+            index_shape[flat_dim] = num_msa
+            gather_index = indices.reshape(index_shape)
+            expand_shape = list(flat_value.shape)
+            expand_shape[flat_dim] = num_msa
+            gathered = torch.gather(
+                flat_value,
+                dim=flat_dim,
+                index=gather_index.expand(expand_shape),
+            )
+            return gathered.reshape(*batch_shape, *gathered.shape[1:])
+
+        return {
+            feat_name: gather_seed_batch(feat_dict[feat_name], dim)
+            for feat_name, dim in dim_dict.items()
+        }
 
     if num_msa == 0:
         indices = torch.empty(0, dtype=torch.long, device=device)

--- a/opendde/model/opendde.py
+++ b/opendde/model/opendde.py
@@ -3,6 +3,7 @@
 import copy
 import os
 import time
+from collections.abc import Sequence
 from contextlib import nullcontext
 from typing import Any, Optional
 
@@ -45,6 +46,7 @@ from opendde.model.modules.pairformer import (
     TemplateEmbedder,
 )
 from opendde.model.modules.primitives import LinearNoBias
+from opendde.model.seed_batch import select_seed_batch_features
 from opendde.model.shape_complementarity import (
     build_shape_comp_pred_outputs,
     compute_shape_complementarity_fields,
@@ -57,6 +59,23 @@ from opendde.utils.logger import get_logger
 from opendde.utils.torch_utils import autocasting_disable_decorator
 
 logger = get_logger(__name__)
+
+
+def _seed_batch_generators(
+    input_feature_dict: dict[str, Any],
+) -> Optional[tuple[torch.Generator, ...]]:
+    inference_seed = input_feature_dict.get("inference_seed")
+    if not isinstance(inference_seed, torch.Tensor) or inference_seed.ndim == 0:
+        return None
+    if inference_seed.ndim != 1 or inference_seed.numel() == 0:
+        raise ValueError(
+            "inference_seed must be a non-empty one-dimensional seed batch; "
+            f"got shape {tuple(inference_seed.shape)}."
+        )
+    return tuple(
+        torch.Generator(device=inference_seed.device).manual_seed(int(seed))
+        for seed in inference_seed.detach().cpu().tolist()
+    )
 
 
 def update_input_feature_dict(input_feature_dict: dict[str, Any]) -> dict[str, Any]:
@@ -782,6 +801,7 @@ class OpenDDE(nn.Module):
         N_cycle: int,
         inplace_safe: bool = False,
         chunk_size: Optional[int] = None,
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
     ) -> tuple[torch.Tensor, ...]:
         """
         The forward pass from the input to pairformer output
@@ -807,6 +827,7 @@ class OpenDDE(nn.Module):
             s_init=s_init,
             inplace_safe=inplace_safe,
             chunk_size=chunk_size,
+            msa_generators=msa_generators,
         )
         if foldcp_result is not None:
             return foldcp_result
@@ -854,6 +875,7 @@ class OpenDDE(nn.Module):
                         triangle_attention=self.configs.triangle_attention,
                         inplace_safe=inplace_safe,
                         chunk_size=chunk_size,
+                        generators=msa_generators,
                     )
                 else:
                     if self.template_embedder.n_blocks > 0:
@@ -874,6 +896,7 @@ class OpenDDE(nn.Module):
                         triangle_attention=self.configs.triangle_attention,
                         inplace_safe=inplace_safe,
                         chunk_size=chunk_size,
+                        generators=msa_generators,
                     )
                 s = s_init + self.linear_no_bias_s(self.layernorm_s(s))
                 s, z = self.pairformer_stack(
@@ -896,6 +919,7 @@ class OpenDDE(nn.Module):
         s_init: torch.Tensor,
         inplace_safe: bool = False,
         chunk_size: Optional[int] = None,
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
     ) -> Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
         mesh = self._maybe_foldcp_mesh()
         if mesh is None:
@@ -950,6 +974,7 @@ class OpenDDE(nn.Module):
                     triangle_attention=self.configs.triangle_attention,
                     inplace_safe=inplace_safe,
                     chunk_size=chunk_size,
+                    generators=msa_generators,
                 )
                 s = s_init + self.linear_no_bias_s(self.layernorm_s(s))
                 s, z_local, z_spec = distributed_pairformer_stack_single_bridge_update(
@@ -989,7 +1014,13 @@ class OpenDDE(nn.Module):
         sample_z_trunk = None if sample_pair_z is not None else z
         rollout_seed = input_feature_dict.get("inference_seed")
         if isinstance(rollout_seed, torch.Tensor):
-            rollout_seed = int(rollout_seed.detach().cpu().item())
+            if rollout_seed.ndim == 0:
+                rollout_seed = int(rollout_seed.detach().cpu().item())
+            elif rollout_seed.ndim != 1:
+                raise ValueError(
+                    "inference_seed must be a scalar or one-dimensional seed batch; "
+                    f"got shape {tuple(rollout_seed.shape)}."
+                )
         elif rollout_seed is not None:
             rollout_seed = int(rollout_seed)
 
@@ -1255,6 +1286,48 @@ class OpenDDE(nn.Module):
         )
         return pred_dict
 
+    def postprocess_seed_batch(
+        self,
+        *,
+        pred_dict: dict[str, Any],
+        input_feature_dict: dict[str, Any],
+        pair_input_feature_dict: dict[str, Any],
+        pair_z: torch.Tensor,
+        N_cycle: int,
+    ) -> list[dict[str, Any]]:
+        """Split the seed dimension before scalar confidence postprocessing."""
+        inference_seed = input_feature_dict.get("inference_seed")
+        if not isinstance(inference_seed, torch.Tensor) or inference_seed.ndim != 1:
+            raise ValueError("Seed-batched postprocessing requires a seed vector.")
+        batch_size = inference_seed.numel()
+        predictions = []
+        for seed_index in range(batch_size):
+            seed_prediction = {}
+            for name, value in pred_dict.items():
+                if not isinstance(value, torch.Tensor):
+                    seed_prediction[name] = value
+                    continue
+                if value.ndim == 0 or value.shape[0] != batch_size:
+                    raise ValueError(
+                        f"Batched prediction {name!r} has shape {tuple(value.shape)} "
+                        f"for seed batch size {batch_size}."
+                    )
+                seed_prediction[name] = value[seed_index]
+
+            self.run_post_confidence_outputs_stage(
+                pred_dict=seed_prediction,
+                input_feature_dict=select_seed_batch_features(
+                    input_feature_dict, seed_index, batch_size
+                ),
+                pair_input_feature_dict=select_seed_batch_features(
+                    pair_input_feature_dict, seed_index, batch_size
+                ),
+                pair_z=pair_z[seed_index],
+                N_cycle=N_cycle,
+            )
+            predictions.append(seed_prediction)
+        return predictions
+
     def run_confidence_head(self, *args: Any, **kwargs: Any) -> Any:
         """
         Runs the confidence head with optional automatic mixed precision (AMP) disabled.
@@ -1410,7 +1483,8 @@ class OpenDDE(nn.Module):
         inplace_safe: bool = True,
         chunk_size: Optional[int] = 4,
         N_model_seed: int = 1,
-    ) -> tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]:
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
+    ) -> tuple[Any, dict[str, Any], dict[str, Any]]:
         """
         Main inference loop, optionally evaluating multiple model seeds.
 
@@ -1423,6 +1497,14 @@ class OpenDDE(nn.Module):
         Returns:
             tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]: Prediction, log, and time dictionaries.
         """
+        inference_seed = input_feature_dict.get("inference_seed")
+        is_seed_batch = (
+            isinstance(inference_seed, torch.Tensor) and inference_seed.ndim == 1
+        )
+        if N_model_seed > 1 and is_seed_batch:
+            raise ValueError(
+                "model.N_model_seed cannot be combined with seed-batched inference."
+            )
         if N_model_seed > 1:
             pred_dicts = []
             log_dicts = []
@@ -1433,6 +1515,7 @@ class OpenDDE(nn.Module):
                     N_cycle=N_cycle,
                     inplace_safe=inplace_safe,
                     chunk_size=chunk_size,
+                    msa_generators=msa_generators,
                 )
                 pred_dicts.append(pred_dict)
                 log_dicts.append(log_dict)
@@ -1472,6 +1555,7 @@ class OpenDDE(nn.Module):
                 N_cycle=N_cycle,
                 inplace_safe=inplace_safe,
                 chunk_size=chunk_size,
+                msa_generators=msa_generators,
             )
 
     def _get_dynamic_chunk_size(self, N_token: int) -> Optional[int]:
@@ -1507,7 +1591,8 @@ class OpenDDE(nn.Module):
         N_cycle: int,
         inplace_safe: bool = True,
         chunk_size: Optional[int] = 4,
-    ) -> tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]:
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
+    ) -> tuple[Any, dict[str, Any], dict[str, Any]]:
         """
         Main inference loop (single model seed) for the Alphafold3 model.
 
@@ -1535,6 +1620,7 @@ class OpenDDE(nn.Module):
                 N_cycle=N_cycle,
                 inplace_safe=inplace_safe,
                 chunk_size=chunk_size,
+                msa_generators=msa_generators,
             )
         if self._maybe_foldcp_mesh() is not None and s_inputs.is_cuda:
             torch.cuda.empty_cache()
@@ -1679,13 +1765,25 @@ class OpenDDE(nn.Module):
             return pred_dict, log_dict, time_tracker
 
         with self._foldcp_stage_context("opendde_post_confidence_outputs", N_token):
-            self.run_post_confidence_outputs_stage(
-                pred_dict=pred_dict,
-                input_feature_dict=input_feature_dict,
-                pair_input_feature_dict=pair_input_feature_dict,
-                pair_z=pair_z,
-                N_cycle=N_cycle,
-            )
+            inference_seed = input_feature_dict.get("inference_seed")
+            if not (
+                isinstance(inference_seed, torch.Tensor) and inference_seed.ndim == 1
+            ):
+                self.run_post_confidence_outputs_stage(
+                    pred_dict=pred_dict,
+                    input_feature_dict=input_feature_dict,
+                    pair_input_feature_dict=pair_input_feature_dict,
+                    pair_z=pair_z,
+                    N_cycle=N_cycle,
+                )
+            else:
+                pred_dict = self.postprocess_seed_batch(
+                    pred_dict=pred_dict,
+                    input_feature_dict=input_feature_dict,
+                    pair_input_feature_dict=pair_input_feature_dict,
+                    pair_z=pair_z,
+                    N_cycle=N_cycle,
+                )
 
         return pred_dict, log_dict, time_tracker
 
@@ -1696,7 +1794,8 @@ class OpenDDE(nn.Module):
         label_dict: Optional[dict[str, Any]] = None,
         mode: str = "inference",
         disable_inplace: bool = False,
-    ) -> tuple[dict[str, torch.Tensor], Optional[dict[str, Any]], dict[str, Any]]:
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
+    ) -> tuple[Any, Optional[dict[str, Any]], dict[str, Any]]:
         """
         Forward pass for structure prediction.
 
@@ -1723,6 +1822,8 @@ class OpenDDE(nn.Module):
             lazy=lazy_relp,
         )
         input_feature_dict = update_input_feature_dict(input_feature_dict)
+        if msa_generators is None:
+            msa_generators = _seed_batch_generators(input_feature_dict)
 
         pred_dict, log_dict, time_tracker = self.main_inference_loop(
             input_feature_dict=input_feature_dict,
@@ -1730,6 +1831,7 @@ class OpenDDE(nn.Module):
             inplace_safe=inplace_safe,
             chunk_size=self.configs.infer_setting.chunk_size,
             N_model_seed=self.N_model_seed,
+            msa_generators=msa_generators,
         )
         log_dict.update({"time": time_tracker})
 

--- a/opendde/model/seed_batch.py
+++ b/opendde/model/seed_batch.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+"""Feature collation helpers for seed-batched inference."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import torch
+
+
+SEED_BATCH_FEATURES = frozenset(
+    {
+        "deletion_mean",
+        "deletion_value",
+        "has_deletion",
+        "msa",
+        "msa_mask",
+        "profile",
+        "ref_atom_name_chars",
+        "ref_charge",
+        "ref_element",
+        "ref_mask",
+        "ref_pos",
+        "ref_space_uid",
+        "restype",
+    }
+)
+
+
+def _stack_tensors(name: str, values: Sequence[Any]) -> torch.Tensor:
+    if not all(isinstance(value, torch.Tensor) for value in values):
+        raise TypeError(f"Seed-batched feature {name!r} must be a tensor.")
+    shapes = {tuple(value.shape) for value in values}
+    if len(shapes) != 1:
+        raise ValueError(
+            f"Seed-batched feature {name!r} must have one shape; got {sorted(shapes)}."
+        )
+    return torch.stack(tuple(values), dim=0)
+
+
+def stack_seed_batch_features(
+    feature_dicts: Sequence[Mapping[str, Any]],
+    seeds: Sequence[int],
+) -> dict[str, Any]:
+    """Stack seed-varying model features and share invariant topology features."""
+    if not feature_dicts or len(feature_dicts) != len(seeds):
+        raise ValueError(
+            "Seed-batched inference requires one feature dictionary per seed; "
+            f"got {len(feature_dicts)} feature dictionaries and {len(seeds)} seeds."
+        )
+
+    reference = feature_dicts[0]
+    reference_keys = set(reference)
+    for feature_dict in feature_dicts[1:]:
+        if set(feature_dict) != reference_keys:
+            raise ValueError(
+                "Seed-batched feature dictionaries must have identical keys."
+            )
+
+    batched = dict(reference)
+    if len(feature_dicts) == 1:
+        batched["inference_seed"] = torch.tensor(
+            int(seeds[0]),
+            dtype=torch.long,
+            device=next(
+                (
+                    value.device
+                    for value in reference.values()
+                    if isinstance(value, torch.Tensor)
+                ),
+                None,
+            ),
+        )
+        return batched
+
+    for name in SEED_BATCH_FEATURES:
+        if name not in reference:
+            continue
+        values = [feature_dict[name] for feature_dict in feature_dicts]
+        batched[name] = _stack_tensors(name, values)
+
+    template_features = {
+        name for name in reference_keys if name.startswith("template_")
+    }
+    for name in template_features:
+        values = [feature_dict[name] for feature_dict in feature_dicts]
+        if not all(isinstance(value, torch.Tensor) for value in values):
+            continue
+        if not all(torch.equal(values[0], value) for value in values[1:]):
+            batched[name] = _stack_tensors(name, values)
+
+    for name in reference_keys - SEED_BATCH_FEATURES - template_features:
+        reference_value = reference[name]
+        if not isinstance(reference_value, torch.Tensor):
+            continue
+        for value in (feature_dict[name] for feature_dict in feature_dicts[1:]):
+            if not isinstance(value, torch.Tensor) or not torch.equal(
+                reference_value, value
+            ):
+                raise ValueError(
+                    "Seed batching requires identical topology features, but "
+                    f"{name!r} differs between seeds."
+                )
+
+    batched["inference_seed"] = torch.tensor(
+        [int(seed) for seed in seeds],
+        dtype=torch.long,
+        device=next(
+            (
+                value.device
+                for value in reference.values()
+                if isinstance(value, torch.Tensor)
+            ),
+            None,
+        ),
+    )
+    return batched
+
+
+def select_seed_batch_features(
+    feature_dict: Mapping[str, Any],
+    seed_index: int,
+    batch_size: int,
+) -> dict[str, Any]:
+    """Select one seed lane while retaining shared topology features."""
+    selected = dict(feature_dict)
+    for name in SEED_BATCH_FEATURES | {"inference_seed", "d_lm", "v_lm"}:
+        value = selected.get(name)
+        if not isinstance(value, torch.Tensor):
+            continue
+        if value.ndim == 0 or value.shape[0] != batch_size:
+            raise ValueError(
+                f"Seed-batched feature {name!r} has invalid shape {tuple(value.shape)} "
+                f"for batch size {batch_size}."
+            )
+        selected[name] = value[seed_index]
+
+    pad_info = selected.get("pad_info")
+    if isinstance(pad_info, Mapping):
+        selected["pad_info"] = {
+            key: (
+                value[seed_index]
+                if isinstance(value, torch.Tensor)
+                and value.ndim > 0
+                and value.shape[0] == batch_size
+                else value
+            )
+            for key, value in pad_info.items()
+        }
+    return selected

--- a/opendde/utils/random.py
+++ b/opendde/utils/random.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+"""Random helpers that preserve one independent stream per seed batch lane."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Optional, TypeAlias
+
+import torch
+
+
+TorchGenerator: TypeAlias = Optional[torch.Generator | Sequence[torch.Generator]]
+
+
+def randn_with_generators(
+    size: Sequence[int],
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    generator: TorchGenerator = None,
+    seed_batch_dim: int = 0,
+) -> torch.Tensor:
+    """Draw Gaussian noise independently for each seed batch lane."""
+    shape = tuple(size)
+    if generator is None or isinstance(generator, torch.Generator):
+        return torch.randn(shape, device=device, dtype=dtype, generator=generator)
+
+    generators = tuple(generator)
+    batch_dim = seed_batch_dim % len(shape)
+    if shape[batch_dim] != len(generators):
+        raise ValueError(
+            "Random seed batch dimension does not match the generator count: "
+            f"shape={shape}, seed_batch_dim={seed_batch_dim}, "
+            f"generators={len(generators)}."
+        )
+    lane_shape = shape[:batch_dim] + shape[batch_dim + 1 :]
+    return torch.stack(
+        [
+            torch.randn(
+                lane_shape,
+                device=device,
+                dtype=dtype,
+                generator=lane_generator,
+            )
+            for lane_generator in generators
+        ],
+        dim=batch_dim,
+    )

--- a/runner/batch_inference.py
+++ b/runner/batch_inference.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Literal, Optional, Union
 
 import click
+import torch.distributed as dist
 import tqdm
 from Bio import SeqIO
 from rdkit import Chem
@@ -27,6 +28,7 @@ from opendde.data.inference.json_parser import lig_file_to_atom_info
 from opendde.data.tools import kalign
 from opendde.data.utils import pdb_to_cif
 from opendde.distributed.foldcp.config import FoldCPConfig
+from opendde.utils.distributed import DIST_WRAPPER
 from opendde.utils.logger import get_logger
 from opendde.utils.logging_config import init_logging
 from runner.cli import CONTEXT_SETTINGS, opendde_cli
@@ -40,6 +42,36 @@ from runner.template_search import update_template_info
 
 logger = get_logger(__name__)
 SUPPORTED_MODELS = tuple(model_configs.keys())
+
+
+def _preprocess_input_for_runner(input_json: str, **kwargs) -> str:
+    """Preprocess once on rank 0 and share the resulting input path."""
+    if DIST_WRAPPER.world_size <= 1:
+        return preprocess_input(input_json, **kwargs)
+
+    local_error: Exception | None = None
+    status: list[tuple[bool, str, str] | None] = [None]
+    if DIST_WRAPPER.rank == 0:
+        try:
+            status[0] = (True, preprocess_input(input_json, **kwargs), "")
+        except Exception as exc:
+            local_error = exc
+            status[0] = (False, "", f"{type(exc).__name__}: {exc}")
+
+    dist.broadcast_object_list(status, src=0)
+    result = status[0]
+    if result is None:
+        raise RuntimeError("Rank 0 broadcast an invalid preprocessing status.")
+
+    succeeded, effective_path, error_message = result
+    if not succeeded:
+        error = RuntimeError(f"Preprocessing failed on rank 0: {error_message}")
+        if local_error is not None:
+            raise error from local_error
+        raise error
+    if not effective_path:
+        raise RuntimeError("Rank 0 broadcast an empty preprocessed input path.")
+    return effective_path
 
 
 def preprocess_input(
@@ -312,8 +344,8 @@ def get_default_runner(
         use_rna_msa (bool): Whether to use RNA MSA.
         kalign_binary_path (Optional[str]): Path to kalign binary.
         use_tfg_guidance (bool): Whether to use TFG guidance.
-        foldcp_mode (str): Fold-CP execution mode.
-        foldcp_size_dp (int): Number of data-parallel ranks.
+        foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
+        foldcp_size_dp (int): Number of independent seed lanes.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
@@ -380,7 +412,7 @@ def get_default_runner(
         f"enable_tf32: {configs.enable_tf32}"
     )
     logger.info(
-        "Fold-CP mode: %s, size_dp=%s, size_cp=%s, mesh=%s, metrics_jsonl=%s",
+        "Inference topology: mode=%s, size_dp=%s, size_cp=%s, mesh=%s, metrics_jsonl=%s",
         foldcp_config.mode,
         foldcp_config.size_dp,
         foldcp_config.size_cp,
@@ -467,8 +499,8 @@ def inference_jsons(
         rfam_database_path (Optional[str]): Rfam database path.
         rna_central_database_path (Optional[str]): RNAcentral database path.
         nhmmer_n_cpu (Optional[int]): Number of CPUs for nhmmer.
-        foldcp_mode (str): Fold-CP execution mode.
-        foldcp_size_dp (int): Number of data-parallel ranks.
+        foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
+        foldcp_size_dp (int): Number of independent seed lanes.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
@@ -484,7 +516,7 @@ def inference_jsons(
         infer_jsons = [json_file]
     else:
         raise RuntimeError(f"Can not read a special file: {json_file}")
-    infer_jsons = [file for file in infer_jsons if file.endswith(".json")]
+    infer_jsons = sorted(file for file in infer_jsons if file.endswith(".json"))
     logger.info(f"Will infer with {len(infer_jsons)} jsons")
     if len(infer_jsons) == 0:
         return
@@ -522,7 +554,7 @@ def inference_jsons(
         configs = runner.configs
         for _, infer_json in enumerate(tqdm.tqdm(infer_jsons)):
             try:
-                configs["input_json_path"] = preprocess_input(
+                configs["input_json_path"] = _preprocess_input_for_runner(
                     infer_json,
                     out_dir=out_dir,
                     use_msa=use_msa,
@@ -542,6 +574,8 @@ def inference_jsons(
                 )
                 infer_predict(runner, configs)
             except Exception as exc:
+                if DIST_WRAPPER.world_size > 1:
+                    raise
                 infer_errors[infer_json] = str(exc)
         if len(infer_errors) > 0:
             logger.warning(f"Run inference failed: {infer_errors}")
@@ -669,13 +703,16 @@ def inference_jsons(
     "--foldcp_mode",
     type=click.Choice(["single", "distributed"]),
     default="single",
-    help="Fold-CP execution mode: original single-card path or distributed CP path.",
+    help=(
+        "Inference mode: normal single-card model path (including seed lanes) "
+        "or distributed Fold-CP path."
+    ),
 )
 @click.option(
     "--foldcp_size_dp",
     type=int,
     default=1,
-    help="Number of data-parallel ranks for Fold-CP.",
+    help="Number of independent seed lanes; values above 1 require P=1.",
 )
 @click.option(
     "--foldcp_size_cp",
@@ -850,8 +887,8 @@ def predict(
         rfam_database_path (Optional[str]): Rfam database path.
         rna_central_database_path (Optional[str]): RNAcentral database path.
         nhmmer_n_cpu (Optional[int]): Number of CPUs for nhmmer.
-        foldcp_mode (str): Fold-CP execution mode.
-        foldcp_size_dp (int): Number of data-parallel ranks.
+        foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
+        foldcp_size_dp (int): Number of independent seed lanes.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.

--- a/runner/batch_inference.py
+++ b/runner/batch_inference.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Literal, Optional, Union
 
 import click
+import torch
 import torch.distributed as dist
 import tqdm
 from Bio import SeqIO
@@ -317,6 +318,7 @@ def get_default_runner(
     foldcp_size_cp: int = 1,
     foldcp_devices: str = "",
     foldcp_metrics_jsonl: str = "",
+    seed_batch_size: int = 1,
     *,
     device: InferenceDevice = "auto",
 ) -> InferenceRunner:
@@ -325,6 +327,7 @@ def get_default_runner(
 
     Args:
         seeds (Optional[list]): List of inference seeds.
+        seed_batch_size (int): Maximum seeds per rank-local model batch.
         dump_dir (str): Output directory for results.
         n_cycle (int): Number of Pairformer cycles.
         n_step (int): Number of diffusion steps.
@@ -345,7 +348,7 @@ def get_default_runner(
         kalign_binary_path (Optional[str]): Path to kalign binary.
         use_tfg_guidance (bool): Whether to use TFG guidance.
         foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
-        foldcp_size_dp (int): Number of independent seed lanes.
+        foldcp_size_dp (int): Number of seed-sharding ranks.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
@@ -371,6 +374,7 @@ def get_default_runner(
     )
     if seeds is not None:
         configs.seeds = seeds
+    configs.seed_batch_size = seed_batch_size
     model_name = configs.model_name
     # the user input configs has the highest priority
     configs.dump_dir = dump_dir
@@ -412,10 +416,12 @@ def get_default_runner(
         f"enable_tf32: {configs.enable_tf32}"
     )
     logger.info(
-        "Inference topology: mode=%s, size_dp=%s, size_cp=%s, mesh=%s, metrics_jsonl=%s",
+        "Inference topology: mode=%s, size_dp=%s, size_cp=%s, "
+        "seed_batch_size=%s, mesh=%s, metrics_jsonl=%s",
         foldcp_config.mode,
         foldcp_config.size_dp,
         foldcp_config.size_cp,
+        configs.seed_batch_size,
         foldcp_config.cp_mesh_shape,
         foldcp_config.metrics_jsonl or "<disabled>",
     )
@@ -460,6 +466,7 @@ def inference_jsons(
     foldcp_size_cp: int = 1,
     foldcp_devices: str = "",
     foldcp_metrics_jsonl: str = "",
+    seed_batch_size: int = 1,
     *,
     device: InferenceDevice = "auto",
 ) -> None:
@@ -471,6 +478,7 @@ def inference_jsons(
         out_dir (str): Directory to save inference results.
         use_msa (bool): Whether to use MSA.
         seeds (Optional[list[int]]): List of inference seeds.
+        seed_batch_size (int): Maximum seeds per rank-local model batch.
         n_cycle (int): Number of cycles.
         n_step (int): Number of diffusion steps.
         n_sample (int): Number of samples.
@@ -500,7 +508,7 @@ def inference_jsons(
         rna_central_database_path (Optional[str]): RNAcentral database path.
         nhmmer_n_cpu (Optional[int]): Number of CPUs for nhmmer.
         foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
-        foldcp_size_dp (int): Number of independent seed lanes.
+        foldcp_size_dp (int): Number of seed-sharding ranks.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
@@ -524,6 +532,7 @@ def inference_jsons(
     infer_errors = {}
     runner = get_default_runner(
         seeds=seeds,
+        seed_batch_size=seed_batch_size,
         dump_dir=out_dir,
         n_cycle=n_cycle,
         n_step=n_step,
@@ -573,6 +582,8 @@ def inference_jsons(
                     nhmmer_n_cpu=nhmmer_n_cpu,
                 )
                 infer_predict(runner, configs)
+            except torch.cuda.OutOfMemoryError:
+                raise
             except Exception as exc:
                 if DIST_WRAPPER.world_size > 1:
                     raise
@@ -595,6 +606,13 @@ def inference_jsons(
     default=None,
     help="Seeds (comma-separated). Overrides JSON modelSeeds. "
     "If unset, uses modelSeeds from the input JSON, or a random seed when absent.",
+)
+@click.option(
+    "--seed_batch_size",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Maximum seeds per rank-local model batch.",
 )
 @click.option("-c", "--cycle", type=int, default=10, help="Pairformer cycle number.")
 @click.option("-p", "--step", type=int, default=200, help="Diffusion steps.")
@@ -704,7 +722,7 @@ def inference_jsons(
     type=click.Choice(["single", "distributed"]),
     default="single",
     help=(
-        "Inference mode: normal single-card model path (including seed lanes) "
+        "Inference mode: normal model path (including seed batching/sharding) "
         "or distributed Fold-CP path."
     ),
 )
@@ -712,7 +730,7 @@ def inference_jsons(
     "--foldcp_size_dp",
     type=int,
     default=1,
-    help="Number of independent seed lanes; values above 1 require P=1.",
+    help="Number of seed-sharding ranks; values above 1 require P=1.",
 )
 @click.option(
     "--foldcp_size_cp",
@@ -811,6 +829,7 @@ def predict(
     input: str,
     out_dir: str,
     seeds: Optional[str],
+    seed_batch_size: int,
     cycle: int,
     step: int,
     sample: int,
@@ -856,6 +875,7 @@ def predict(
         out_dir (str): Output directory for results.
         seeds (Optional[str]): Comma-separated seeds; overrides JSON modelSeeds.
             When None, falls back to JSON modelSeeds or a random seed.
+        seed_batch_size (int): Maximum seeds per rank-local model batch.
         cycle (int): Number of cycles.
         step (int): Number of diffusion steps.
         sample (int): Number of samples.
@@ -888,7 +908,7 @@ def predict(
         rna_central_database_path (Optional[str]): RNAcentral database path.
         nhmmer_n_cpu (Optional[int]): Number of CPUs for nhmmer.
         foldcp_mode (str): Single-card or distributed Fold-CP execution mode.
-        foldcp_size_dp (int): Number of independent seed lanes.
+        foldcp_size_dp (int): Number of seed-sharding ranks.
         foldcp_size_cp (int): Number of context-parallel ranks.
         foldcp_devices (str): Optional visible device list recorded in metrics.
         foldcp_metrics_jsonl (str): Optional JSONL path for benchmark records.
@@ -957,6 +977,7 @@ def predict(
         out_dir,
         use_msa,
         seeds=seed_list,
+        seed_batch_size=seed_batch_size,
         n_cycle=cycle,
         n_step=step,
         n_sample=sample,

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -6,13 +6,15 @@ import os
 import random
 import time
 import traceback
-from collections.abc import Mapping, Sized
+from collections.abc import Iterator, Mapping, Sequence, Sized
 from contextlib import nullcontext
+from dataclasses import dataclass
 from datetime import timedelta
 from os.path import exists as opexists
 from os.path import join as opjoin
-from typing import Any, cast
+from typing import Any, Optional, cast
 
+import numpy as np
 import torch
 import torch.distributed as dist
 
@@ -34,6 +36,7 @@ from opendde.distributed.foldcp.metrics import (
     measure_foldcp_stage,
 )
 from opendde.model.opendde import OpenDDE
+from opendde.model.seed_batch import stack_seed_batch_features
 from opendde.model.triangular.layers import skip_random_init
 from opendde.utils.distributed import DIST_WRAPPER
 from opendde.utils.download import (
@@ -157,6 +160,33 @@ class InferenceRunner(object):
             f"global rank: {DIST_WRAPPER.rank}, local rank: {DIST_WRAPPER.local_rank}"
         )
         expected_world_size = self.foldcp_config.size_dp * self.foldcp_config.size_cp
+        seed_batch_size = getattr(self.configs, "seed_batch_size", 1)
+        if seed_batch_size < 1:
+            raise ValueError(f"seed_batch_size must be >= 1; got {seed_batch_size}.")
+        if self.foldcp_config.size_cp > 1 and seed_batch_size > 1:
+            raise ValueError(
+                "Seed batching is supported by the normal P=1 model path only; "
+                f"got foldcp_size_cp={self.foldcp_config.size_cp} and "
+                f"seed_batch_size={seed_batch_size}."
+            )
+        if getattr(self.configs, "num_workers", 0) > 0 and seed_batch_size > 1:
+            raise ValueError(
+                "Seed batching requires num_workers=0 so each seed's featurization "
+                "RNG stream can be preserved across input records."
+            )
+        model = getattr(self.configs, "model", None)
+        n_model_seed = getattr(model, "N_model_seed", 1)
+        if seed_batch_size > 1 and n_model_seed > 1:
+            raise ValueError(
+                "Seed batching requires model.N_model_seed=1; "
+                f"got model.N_model_seed={n_model_seed}."
+            )
+        sample_diffusion = getattr(self.configs, "sample_diffusion", None)
+        guidance = getattr(sample_diffusion, "guidance", {})
+        if seed_batch_size > 1 and bool(guidance.get("enable", False)):
+            raise ValueError(
+                "Seed batching cannot be combined with Training-Free Guidance."
+            )
         if DIST_WRAPPER.world_size != expected_world_size:
             raise RuntimeError(
                 "Inference topology requires "
@@ -338,7 +368,12 @@ class InferenceRunner(object):
         )
 
     @torch.no_grad()
-    def predict(self, data: Mapping[str, Mapping[str, Any]]) -> dict[str, torch.Tensor]:
+    def predict(
+        self,
+        data: Mapping[str, Mapping[str, Any]],
+        *,
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
+    ) -> Any:
         """
         Run model prediction on the provided data.
 
@@ -382,9 +417,49 @@ class InferenceRunner(object):
                 label_full_dict=None,
                 label_dict=None,
                 mode="inference",
+                msa_generators=msa_generators,
             )
 
         return prediction
+
+    @torch.no_grad()
+    def predict_seed_batch(
+        self,
+        data_batch: Sequence[Mapping[str, Any]],
+        seeds: Sequence[int],
+        *,
+        msa_generators: Optional[Sequence[torch.Generator]] = None,
+    ) -> list[dict[str, Any]]:
+        """Run one model forward for a rank-local batch of independent seeds."""
+        if not data_batch or len(data_batch) != len(seeds):
+            raise ValueError(
+                "Seed-batched prediction requires one data record per seed; "
+                f"got {len(data_batch)} records and {len(seeds)} seeds."
+            )
+
+        sample_names = {str(data.get("sample_name", "unknown")) for data in data_batch}
+        if len(sample_names) != 1:
+            raise ValueError(
+                f"Seed-batched data must describe one sample; got {sorted(sample_names)}."
+            )
+
+        data = dict(data_batch[0])
+        data["input_feature_dict"] = stack_seed_batch_features(
+            [data["input_feature_dict"] for data in data_batch],
+            seeds,
+        )
+        predictions = self.predict(data, msa_generators=msa_generators)
+
+        if len(seeds) == 1 and isinstance(predictions, dict):
+            return [predictions]
+
+        if not isinstance(predictions, list) or len(predictions) != len(seeds):
+            raise RuntimeError(
+                "Seed-batched model output does not match the requested seeds: "
+                f"seeds={list(seeds)}, output_type={type(predictions).__name__}, "
+                f"output_count={len(predictions) if isinstance(predictions, list) else 'n/a'}."
+            )
+        return predictions
 
     def print(self, msg: str) -> None:
         """
@@ -461,15 +536,18 @@ def _resolve_local_inference_seeds(configs: Any) -> list[int]:
     return seeds
 
 
-def _validate_seed_parallel_seeds(seeds: list[int], size_dp: int) -> None:
-    if size_dp <= 1:
-        return
-    if len(set(seeds)) != len(seeds):
+def _validate_seed_parallel_seeds(
+    seeds: list[int], size_dp: int, seed_batch_size: int = 1
+) -> None:
+    if seed_batch_size < 1:
+        raise ValueError(f"seed_batch_size must be >= 1; got {seed_batch_size}.")
+    if (size_dp > 1 or seed_batch_size > 1) and len(set(seeds)) != len(seeds):
         raise ValueError(
-            "Seed-parallel inference requires unique seeds; "
-            f"got {seeds} for foldcp_size_dp={size_dp}."
+            "Seed-parallel inference requires unique seeds when sharding or batching; "
+            f"got {seeds} for foldcp_size_dp={size_dp}, "
+            f"seed_batch_size={seed_batch_size}."
         )
-    if len(seeds) < size_dp:
+    if size_dp > 1 and len(seeds) < size_dp:
         raise ValueError(
             "Seed-parallel inference requires at least one seed per lane; "
             f"got {len(seeds)} seeds for foldcp_size_dp={size_dp}."
@@ -482,11 +560,23 @@ def _seeds_for_rank(seeds: list[int], size_dp: int, rank: int) -> list[int]:
     return seeds[rank::size_dp]
 
 
-def _resolve_inference_seeds(configs: Any, size_dp: int) -> list[int]:
+def _seed_batches_for_rank(
+    seeds: list[int], size_dp: int, rank: int, seed_batch_size: int
+) -> list[list[int]]:
+    local_seeds = _seeds_for_rank(seeds, size_dp, rank)
+    return [
+        local_seeds[start : start + seed_batch_size]
+        for start in range(0, len(local_seeds), seed_batch_size)
+    ]
+
+
+def _resolve_inference_seeds(
+    configs: Any, size_dp: int, seed_batch_size: int = 1
+) -> list[int]:
     """Resolve and validate seeds on rank 0, then share them with peers."""
     if DIST_WRAPPER.world_size <= 1:
         seeds = _resolve_local_inference_seeds(configs)
-        _validate_seed_parallel_seeds(seeds, size_dp)
+        _validate_seed_parallel_seeds(seeds, size_dp, seed_batch_size)
         return seeds
 
     local_error: Exception | None = None
@@ -494,7 +584,7 @@ def _resolve_inference_seeds(configs: Any, size_dp: int) -> list[int]:
     if DIST_WRAPPER.rank == 0:
         try:
             seeds = _resolve_local_inference_seeds(configs)
-            _validate_seed_parallel_seeds(seeds, size_dp)
+            _validate_seed_parallel_seeds(seeds, size_dp, seed_batch_size)
             status[0] = (True, seeds, "")
         except Exception as exc:
             local_error = exc
@@ -516,6 +606,200 @@ def _resolve_inference_seeds(configs: Any, size_dp: int) -> list[int]:
     return seeds
 
 
+@dataclass
+class _SeedDataLane:
+    iterator: Iterator[Any]
+    python_state: object
+    numpy_state: tuple[Any, ...]
+    torch_state: torch.Tensor
+
+
+def _capture_featurization_random_state() -> tuple[
+    object, tuple[Any, ...], torch.Tensor
+]:
+    return random.getstate(), np.random.get_state(), torch.random.get_rng_state()
+
+
+def _restore_featurization_random_state(lane: _SeedDataLane) -> None:
+    random.setstate(lane.python_state)
+    np.random.set_state(lane.numpy_state)
+    torch.random.set_rng_state(lane.torch_state)
+
+
+def _seed_data_lanes(
+    dataloader: Any,
+    seeds: Sequence[int],
+    deterministic: bool,
+) -> list[_SeedDataLane]:
+    lanes = []
+    for seed in seeds:
+        seed_everything(seed=int(seed), deterministic=deterministic)
+        iterator = iter(dataloader)
+        python_state, numpy_state, torch_state = _capture_featurization_random_state()
+        lanes.append(_SeedDataLane(iterator, python_state, numpy_state, torch_state))
+    return lanes
+
+
+def _next_seed_data(lane: _SeedDataLane) -> Any:
+    _restore_featurization_random_state(lane)
+    batch = next(lane.iterator)
+    lane.python_state, lane.numpy_state, lane.torch_state = (
+        _capture_featurization_random_state()
+    )
+    return batch
+
+
+def _seed_batch_msa_generators(
+    lanes: Sequence[_SeedDataLane],
+    seeds: Sequence[int],
+    device: torch.device,
+) -> tuple[torch.Generator, ...]:
+    generators = []
+    for lane, seed in zip(lanes, seeds):
+        generator = torch.Generator(device=device)
+        if device.type == "cpu":
+            generator.set_state(lane.torch_state)
+        else:
+            generator.manual_seed(int(seed))
+        generators.append(generator)
+    return tuple(generators)
+
+
+def _sync_cpu_msa_generators(
+    lanes: Sequence[_SeedDataLane],
+    generators: Sequence[torch.Generator],
+    *,
+    before_model: bool,
+    device: torch.device,
+) -> None:
+    if device.type != "cpu":
+        return
+    for lane, generator in zip(lanes, generators):
+        if before_model:
+            generator.set_state(lane.torch_state)
+        else:
+            lane.torch_state = generator.get_state()
+
+
+def _infer_seed_batch_record(
+    runner: InferenceRunner,
+    configs: Any,
+    lanes: Sequence[_SeedDataLane],
+    seed_batch: Sequence[int],
+    msa_generators: Sequence[torch.Generator],
+    num_data: int,
+) -> None:
+    sample_name = "unknown"
+    model_batch_size = 0
+    try:
+        seed_records = [_next_seed_data(lane)[0] for lane in lanes]
+        sample_names = {record[0]["sample_name"] for record in seed_records}
+        if len(sample_names) != 1:
+            raise RuntimeError(
+                f"Seed data lanes produced different samples: {sorted(sample_names)}."
+            )
+        sample_name = next(iter(sample_names))
+
+        valid_indices = []
+        for index, (seed, record) in enumerate(zip(seed_batch, seed_records)):
+            _, _, data_error_message = record
+            if data_error_message:
+                logger.error(
+                    f"Data error for {sample_name} [seed:{seed}]: {data_error_message}"
+                )
+                with open(
+                    opjoin(runner.error_dir, f"{sample_name}.txt"),
+                    "a",
+                    encoding="utf-8",
+                ) as f:
+                    f.write(data_error_message)
+            else:
+                valid_indices.append(index)
+        if not valid_indices:
+            return
+
+        valid_seeds = [seed_batch[index] for index in valid_indices]
+        model_batch_size = len(valid_seeds)
+        valid_records = [seed_records[index] for index in valid_indices]
+        valid_data = [record[0] for record in valid_records]
+        valid_lanes = [lanes[index] for index in valid_indices]
+        valid_generators = [msa_generators[index] for index in valid_indices]
+        data = valid_data[0]
+        start_time = time.time()
+
+        logger.info(
+            f"[Rank {DIST_WRAPPER.rank} ({data['sample_index'] + 1}/{num_data})] "
+            f"{sample_name} [seeds:{valid_seeds}]: "
+            f"N_asym {data['N_asym'].item()}, N_token {data['N_token'].item()}, "
+            f"N_atom {data['N_atom'].item()}, N_msa {data['N_msa'].item()}"
+        )
+        new_configs = update_inference_configs(configs, data["N_token"].item())
+        runner.update_model_configs(new_configs)
+        _sync_cpu_msa_generators(
+            valid_lanes,
+            valid_generators,
+            before_model=True,
+            device=runner.device,
+        )
+        try:
+            predictions = runner.predict_seed_batch(
+                valid_data,
+                valid_seeds,
+                msa_generators=valid_generators,
+            )
+        finally:
+            _sync_cpu_msa_generators(
+                valid_lanes,
+                valid_generators,
+                before_model=False,
+                device=runner.device,
+            )
+
+        if not (runner.foldcp_config.enabled and DIST_WRAPPER.rank != 0):
+            for seed, record, prediction in zip(
+                valid_seeds, valid_records, predictions
+            ):
+                seed_data, atom_array, _ = record
+                runner.dumper.dump(
+                    group_name="",
+                    pdb_id=sample_name,
+                    seed=seed,
+                    pred_dict=prediction,
+                    atom_array=atom_array,
+                    entity_poly_type={
+                        key: value
+                        for key, value in seed_data["entity_poly_type"].items()
+                        if value != "non-polymer"
+                    },
+                )
+        logger.info(
+            f"[Rank {DIST_WRAPPER.rank}] {sample_name} "
+            f"[seeds:{valid_seeds}] succeeded. "
+            f"Model forward time: {time.time() - start_time:.2f}s. "
+            f"Results saved to {configs.dump_dir}"
+        )
+    except Exception as exc:
+        if isinstance(exc, torch.cuda.OutOfMemoryError) and model_batch_size > 1:
+            logger.exception(
+                "[Rank %s] %s seed batch %s ran out of CUDA memory.",
+                DIST_WRAPPER.rank,
+                sample_name,
+                list(seed_batch),
+            )
+            raise
+        error_message = (
+            f"[Rank {DIST_WRAPPER.rank}] {sample_name} failed: {exc}\n"
+            f"{traceback.format_exc()}"
+        )
+        logger.error(error_message)
+        with open(
+            opjoin(runner.error_dir, f"{sample_name}.txt"),
+            "a",
+            encoding="utf-8",
+        ) as f:
+            f.write(error_message)
+
+
 def infer_predict(runner: InferenceRunner, configs: Any) -> None:
     """
     Run the full inference process for the given runner and configurations.
@@ -528,9 +812,12 @@ def infer_predict(runner: InferenceRunner, configs: Any) -> None:
     # Data loading
     logger.info(f"Loading data from {configs.input_json_path}")
     size_dp = runner.foldcp_config.size_dp
-    seeds = _resolve_inference_seeds(configs, size_dp)
-    seeds = _seeds_for_rank(seeds, size_dp, DIST_WRAPPER.rank)
-    logger.info(f"[Rank {DIST_WRAPPER.rank}] Assigned seeds: {seeds}")
+    seed_batch_size = getattr(configs, "seed_batch_size", 1)
+    seeds = _resolve_inference_seeds(configs, size_dp, seed_batch_size)
+    seed_batches = _seed_batches_for_rank(
+        seeds, size_dp, DIST_WRAPPER.rank, seed_batch_size
+    )
+    logger.info(f"[Rank {DIST_WRAPPER.rank}] Assigned seed batches: {seed_batches}")
 
     try:
         dataloader = get_inference_dataloader(configs=configs)
@@ -546,88 +833,32 @@ def infer_predict(runner: InferenceRunner, configs: Any) -> None:
     num_data = len(cast(Sized, dataloader.dataset))
     t0_start = time.time()
     with disable_cudnn_benchmark(runner.device):
-        for seed in seeds:
-            seed_everything(seed=seed, deterministic=configs.deterministic)
+        for seed_batch in seed_batches:
             cleanup_device_memory(runner.device)
             t1_start = time.time()
-            for batch in dataloader:
-                sample_name = "unknown"
-                data = None
-                atom_array = None
-                prediction = None
+            lanes = _seed_data_lanes(
+                dataloader, seed_batch, deterministic=configs.deterministic
+            )
+            msa_generators = _seed_batch_msa_generators(
+                lanes, seed_batch, runner.device
+            )
+            for _ in range(num_data):
                 try:
-                    t2_start = time.time()
-                    data, atom_array, data_error_message = batch[0]
-                    sample_name = data["sample_name"]
-
-                    if len(data_error_message) > 0:
-                        logger.error(
-                            f"Data error for {sample_name}: {data_error_message}"
-                        )
-                        with open(
-                            opjoin(runner.error_dir, f"{sample_name}.txt"),
-                            "a",
-                            encoding="utf-8",
-                        ) as f:
-                            f.write(data_error_message)
-                        continue
-
-                    logger.info(
-                        f"[Rank {DIST_WRAPPER.rank} ({data['sample_index'] + 1}/{num_data})] "
-                        f"{sample_name} [seed:{seed}]: "
-                        f"N_asym {data['N_asym'].item()}, N_token {data['N_token'].item()}, "
-                        f"N_atom {data['N_atom'].item()}, N_msa {data['N_msa'].item()}"
+                    _infer_seed_batch_record(
+                        runner=runner,
+                        configs=configs,
+                        lanes=lanes,
+                        seed_batch=seed_batch,
+                        msa_generators=msa_generators,
+                        num_data=num_data,
                     )
-                    new_configs = update_inference_configs(
-                        configs, data["N_token"].item()
-                    )
-                    data["input_feature_dict"]["inference_seed"] = torch.tensor(
-                        int(seed),
-                        dtype=torch.long,
-                    )
-                    runner.update_model_configs(new_configs)
-                    prediction = runner.predict(data)
-                    if not (runner.foldcp_config.enabled and DIST_WRAPPER.rank != 0):
-                        runner.dumper.dump(
-                            group_name="",
-                            pdb_id=sample_name,
-                            seed=seed,
-                            pred_dict=prediction,
-                            atom_array=atom_array,
-                            entity_poly_type={
-                                k: v
-                                for k, v in data["entity_poly_type"].items()
-                                if v != "non-polymer"
-                            },
-                        )
-                    t2_end = time.time()
-                    logger.info(
-                        f"[Rank {DIST_WRAPPER.rank}] {sample_name} [seed:{seed}] succeeded. "
-                        f"Model forward time: {t2_end - t2_start:.2f}s. "
-                        f"Results saved to {configs.dump_dir}"
-                    )
-                except Exception as e:
-                    error_message = (
-                        f"[Rank {DIST_WRAPPER.rank}] {sample_name} failed: {e}\n"
-                        f"{traceback.format_exc()}"
-                    )
-                    logger.error(error_message)
-                    with open(
-                        opjoin(runner.error_dir, f"{sample_name}.txt"),
-                        "a",
-                        encoding="utf-8",
-                    ) as f:
-                        f.write(error_message)
                 finally:
-                    # `batch` also references the tensors moved to the device, so
-                    # drop it here to release them on every path, including the
-                    # unpacking above failing.
-                    del batch, data, atom_array, prediction
                     cleanup_device_memory(runner.device, collect_garbage=False)
             cleanup_device_memory(runner.device, synchronize=True)
             t1_end = time.time()
             logger.info(
-                f"[Rank {DIST_WRAPPER.rank}] Seed {seed} completed in {t1_end - t1_start:.2f}s."
+                f"[Rank {DIST_WRAPPER.rank}] Seed batch {seed_batch} completed in "
+                f"{t1_end - t1_start:.2f}s."
             )
     # Remove the error directory if it's empty
     if opexists(runner.error_dir):

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -156,16 +156,16 @@ class InferenceRunner(object):
             f"Distributed environment: world size: {DIST_WRAPPER.world_size}, "
             f"global rank: {DIST_WRAPPER.rank}, local rank: {DIST_WRAPPER.local_rank}"
         )
-        if self.foldcp_config.enabled:
-            expected_world_size = (
-                self.foldcp_config.size_dp * self.foldcp_config.size_cp
+        expected_world_size = self.foldcp_config.size_dp * self.foldcp_config.size_cp
+        if DIST_WRAPPER.world_size != expected_world_size:
+            raise RuntimeError(
+                "Inference topology requires "
+                f"WORLD_SIZE={expected_world_size} for "
+                f"foldcp_size_dp={self.foldcp_config.size_dp}, "
+                f"foldcp_size_cp={self.foldcp_config.size_cp}; got "
+                f"WORLD_SIZE={DIST_WRAPPER.world_size}. Example: "
+                f"{self.foldcp_config.launch_hint()}"
             )
-            if DIST_WRAPPER.world_size != expected_world_size:
-                raise RuntimeError(
-                    "Distributed Fold-CP must be launched with torchrun using "
-                    f"{expected_world_size} processes. Example: "
-                    f"{self.foldcp_config.launch_hint()}"
-                )
 
         self.device = select_torch_device(
             self.configs.device, local_rank=DIST_WRAPPER.local_rank
@@ -186,19 +186,19 @@ class InferenceRunner(object):
         if DIST_WRAPPER.world_size > 1:
             if not self.use_cuda:
                 raise RuntimeError(
-                    "Distributed Fold-CP inference requires NVIDIA CUDA; CPU "
+                    "Distributed inference requires NVIDIA CUDA; CPU "
                     "supports single-process inference only."
                 )
             if not dist.is_nccl_available():
                 raise RuntimeError(
-                    "Distributed Fold-CP inference requires the NCCL backend, "
+                    "Distributed inference requires the NCCL backend, "
                     "which is unavailable in this PyTorch build. Windows "
                     "distributed inference is not currently supported."
                 )
             if dist.is_initialized():
                 if dist.get_backend() != "nccl":
                     raise RuntimeError(
-                        "Distributed Fold-CP requires an NCCL process group."
+                        "Distributed inference requires an NCCL process group."
                     )
             else:
                 dist.init_process_group(
@@ -436,17 +436,7 @@ def update_inference_configs(configs: OpenDDEConfig, n_token: int) -> OpenDDECon
     return configs
 
 
-def infer_predict(runner: InferenceRunner, configs: Any) -> None:
-    """
-    Run the full inference process for the given runner and configurations.
-    Processes all samples in the dataloader for each specified seed.
-
-    Args:
-        runner (InferenceRunner): The initialized runner instance.
-        configs (Any): Inference configurations.
-    """
-    # Data loading
-    logger.info(f"Loading data from {configs.input_json_path}")
+def _resolve_local_inference_seeds(configs: Any) -> list[int]:
     with open(configs.input_json_path, "r", encoding="utf-8") as f:
         json_data = json.load(f)
 
@@ -468,6 +458,79 @@ def infer_predict(runner: InferenceRunner, configs: Any) -> None:
     else:
         seeds = [random.randint(1, 65536)]
         logger.info(f"No seeds provided; sampled random seed: {seeds}")
+    return seeds
+
+
+def _validate_seed_parallel_seeds(seeds: list[int], size_dp: int) -> None:
+    if size_dp <= 1:
+        return
+    if len(set(seeds)) != len(seeds):
+        raise ValueError(
+            "Seed-parallel inference requires unique seeds; "
+            f"got {seeds} for foldcp_size_dp={size_dp}."
+        )
+    if len(seeds) < size_dp:
+        raise ValueError(
+            "Seed-parallel inference requires at least one seed per lane; "
+            f"got {len(seeds)} seeds for foldcp_size_dp={size_dp}."
+        )
+
+
+def _seeds_for_rank(seeds: list[int], size_dp: int, rank: int) -> list[int]:
+    if size_dp <= 1:
+        return seeds
+    return seeds[rank::size_dp]
+
+
+def _resolve_inference_seeds(configs: Any, size_dp: int) -> list[int]:
+    """Resolve and validate seeds on rank 0, then share them with peers."""
+    if DIST_WRAPPER.world_size <= 1:
+        seeds = _resolve_local_inference_seeds(configs)
+        _validate_seed_parallel_seeds(seeds, size_dp)
+        return seeds
+
+    local_error: Exception | None = None
+    status: list[tuple[bool, list[int] | None, str] | None] = [None]
+    if DIST_WRAPPER.rank == 0:
+        try:
+            seeds = _resolve_local_inference_seeds(configs)
+            _validate_seed_parallel_seeds(seeds, size_dp)
+            status[0] = (True, seeds, "")
+        except Exception as exc:
+            local_error = exc
+            status[0] = (False, None, f"{type(exc).__name__}: {exc}")
+
+    dist.broadcast_object_list(status, src=0)
+    result = status[0]
+    if result is None:
+        raise RuntimeError("Rank 0 broadcast an invalid seed-resolution status.")
+
+    succeeded, seeds, error_message = result
+    if not succeeded:
+        error = RuntimeError(f"Seed resolution failed on rank 0: {error_message}")
+        if local_error is not None:
+            raise error from local_error
+        raise error
+    if not isinstance(seeds, list):
+        raise RuntimeError("Rank 0 broadcast invalid inference seeds.")
+    return seeds
+
+
+def infer_predict(runner: InferenceRunner, configs: Any) -> None:
+    """
+    Run the full inference process for the given runner and configurations.
+    Processes all samples in the dataloader for each specified seed.
+
+    Args:
+        runner (InferenceRunner): The initialized runner instance.
+        configs (Any): Inference configurations.
+    """
+    # Data loading
+    logger.info(f"Loading data from {configs.input_json_path}")
+    size_dp = runner.foldcp_config.size_dp
+    seeds = _resolve_inference_seeds(configs, size_dp)
+    seeds = _seeds_for_rank(seeds, size_dp, DIST_WRAPPER.rank)
+    logger.info(f"[Rank {DIST_WRAPPER.rank}] Assigned seeds: {seeds}")
 
     try:
         dataloader = get_inference_dataloader(configs=configs)

--- a/tests/test_foldcp_cpn.py
+++ b/tests/test_foldcp_cpn.py
@@ -8,6 +8,58 @@ from opendde.distributed.foldcp.layout import FoldCP2DLayout
 from opendde.distributed.foldcp.pair_sharding import shard_pair_tensor
 
 
+@pytest.mark.parametrize(
+    ("mode", "size_dp", "size_cp"),
+    [
+        ("single", 1, 1),
+        ("single", 2, 1),
+        ("single", 3, 1),
+        ("single", 4, 1),
+        ("distributed", 1, 2),
+        ("distributed", 1, 3),
+        ("distributed", 1, 4),
+    ],
+)
+def test_supported_inference_topologies(mode, size_dp, size_cp):
+    config = FoldCPConfig.from_runtime_args(
+        mode=mode,
+        size_dp=size_dp,
+        size_cp=size_cp,
+    )
+
+    assert (config.size_dp, config.size_cp) == (size_dp, size_cp)
+
+
+def test_seed_parallel_launch_hint_uses_torchrun():
+    config = FoldCPConfig.from_runtime_args(mode="single", size_dp=4, size_cp=1)
+
+    assert config.launch_hint() == (
+        "torchrun --standalone --nproc_per_node 4 "
+        "-m runner.batch_inference pred --foldcp_mode single "
+        "--foldcp_size_dp 4 --foldcp_size_cp 1"
+    )
+    assert config.enabled is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "size_dp", "size_cp", "message"),
+    [
+        ("single", 2, 2, "Hybrid seed-parallel and Fold-CP"),
+        ("distributed", 2, 2, "Hybrid seed-parallel and Fold-CP"),
+        ("single", 1, 2, "foldcp_mode='single' requires"),
+        ("distributed", 2, 1, "foldcp_mode='distributed' requires foldcp_size_dp=1"),
+        ("distributed", 1, 1, "foldcp_mode='distributed' requires foldcp_size_cp > 1"),
+    ],
+)
+def test_rejected_inference_topologies(mode, size_dp, size_cp, message):
+    with pytest.raises(ValueError, match=message):
+        FoldCPConfig.from_runtime_args(
+            mode=mode,
+            size_dp=size_dp,
+            size_cp=size_cp,
+        )
+
+
 @pytest.mark.parametrize("p", range(2, 9))
 def test_distributed_config_uses_one_by_p_for_any_cp_size(monkeypatch, p):
     """Catch reintroducing the perfect-square-only CP launch restriction."""

--- a/tests/test_generator_tfg.py
+++ b/tests/test_generator_tfg.py
@@ -17,6 +17,7 @@
 """Generator-level Training-Free Guidance regression tests."""
 
 import numpy as np
+import pytest
 import torch
 
 from opendde.model.generator import InferenceNoiseScheduler, sample_diffusion
@@ -152,3 +153,80 @@ def test_tfg_guidance_forwards_pair_z_spec_to_denoiser():
     assert out.shape == (1, 6, 3)
     assert seen_specs
     assert all(spec is sentinel for spec in seen_specs)
+
+
+def test_seed_batched_diffusion_matches_independent_scalar_streams():
+    seeds = [101, 202]
+    scalar_inputs = _inputs(n_step=2)
+    batched_inputs = {
+        **scalar_inputs,
+        "s_inputs": torch.stack([scalar_inputs["s_inputs"]] * len(seeds)),
+        "s_trunk": torch.stack([scalar_inputs["s_trunk"]] * len(seeds)),
+        "z_trunk": torch.stack([scalar_inputs["z_trunk"]] * len(seeds)),
+    }
+
+    actual = sample_diffusion(
+        N_sample=2,
+        rollout_seed=seeds,
+        **batched_inputs,
+    )
+    expected = torch.stack(
+        [
+            sample_diffusion(
+                N_sample=2,
+                rollout_seed=seed,
+                **scalar_inputs,
+            )
+            for seed in seeds
+        ]
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_seed_batched_diffusion_rejects_tfg():
+    scalar_inputs = _inputs(n_step=1)
+    batched_inputs = {
+        **scalar_inputs,
+        "s_inputs": torch.stack([scalar_inputs["s_inputs"]] * 2),
+        "s_trunk": torch.stack([scalar_inputs["s_trunk"]] * 2),
+        "z_trunk": torch.stack([scalar_inputs["z_trunk"]] * 2),
+    }
+
+    with pytest.raises(ValueError, match="does not support seed batching"):
+        sample_diffusion(
+            N_sample=1,
+            rollout_seed=[101, 202],
+            guidance_configs=_tfg_cfg(),
+            **batched_inputs,
+        )
+
+
+def test_seed_batched_diffusion_rejects_seed_count_mismatch():
+    scalar_inputs = _inputs(n_step=1)
+    batched_inputs = {
+        **scalar_inputs,
+        "s_inputs": torch.stack([scalar_inputs["s_inputs"]] * 2),
+        "s_trunk": torch.stack([scalar_inputs["s_trunk"]] * 2),
+        "z_trunk": torch.stack([scalar_inputs["z_trunk"]] * 2),
+    }
+
+    with pytest.raises(ValueError, match="batch_shape"):
+        sample_diffusion(
+            N_sample=1,
+            rollout_seed=[101],
+            **batched_inputs,
+        )
+
+
+def test_scalar_tensor_rollout_seed_matches_integer_seed():
+    inputs = _inputs(n_step=1)
+
+    expected = sample_diffusion(N_sample=1, rollout_seed=101, **inputs)
+    actual = sample_diffusion(
+        N_sample=1,
+        rollout_seed=torch.tensor(101),
+        **inputs,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/test_inference_config.py
+++ b/tests/test_inference_config.py
@@ -303,6 +303,386 @@ def test_foldcp_config_validation_is_independent_of_process_environment(monkeypa
     assert FoldCPConfig().validate().mode == "single"
 
 
+@pytest.mark.parametrize(
+    ("mode", "size_dp", "size_cp", "world_size"),
+    [
+        ("single", 1, 1, 1),
+        ("single", 2, 1, 2),
+        ("single", 3, 1, 3),
+        ("single", 4, 1, 4),
+        ("distributed", 1, 2, 2),
+        ("distributed", 1, 3, 3),
+        ("distributed", 1, 4, 4),
+    ],
+)
+def test_matching_world_size_reaches_device_selection(
+    monkeypatch, mode, size_dp, size_cp, world_size
+):
+    from opendde.distributed.foldcp.config import FoldCPConfig
+    from runner import inference
+
+    class DeviceSelectionReached(Exception):
+        pass
+
+    runner = object.__new__(inference.InferenceRunner)
+    runner.foldcp_config = FoldCPConfig.from_runtime_args(
+        mode=mode,
+        size_dp=size_dp,
+        size_cp=size_cp,
+    )
+    runner.configs = SimpleNamespace(device="auto")
+    runner.print = lambda _message: None
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=world_size, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "select_torch_device",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(DeviceSelectionReached),
+    )
+
+    with pytest.raises(DeviceSelectionReached):
+        runner.init_env()
+
+
+def test_world_size_mismatch_fails_before_device_or_model_selection(monkeypatch):
+    from opendde.distributed.foldcp.config import FoldCPConfig
+    from runner import inference
+
+    runner = object.__new__(inference.InferenceRunner)
+    runner.foldcp_config = FoldCPConfig.from_runtime_args(
+        mode="single", size_dp=4, size_cp=1
+    )
+    runner.configs = SimpleNamespace(device="auto")
+    runner.print = lambda _message: None
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "select_torch_device",
+        lambda *_args, **_kwargs: pytest.fail(
+            "world-size mismatch must fail before device or model selection"
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"WORLD_SIZE=4.*foldcp_size_dp=4.*foldcp_size_cp=1.*WORLD_SIZE=2",
+    ):
+        runner.init_env()
+
+
+def test_predict_help_describes_seed_lanes():
+    from click.testing import CliRunner
+
+    from runner import batch_inference
+
+    result = CliRunner().invoke(
+        batch_inference.predict,
+        ["--help"],
+        terminal_width=160,
+    )
+
+    assert result.exit_code == 0
+    assert "--foldcp_size_dp" in result.output
+    assert "Number of independent seed lanes" in result.output
+    assert "normal single-card model path (including seed lanes)" in result.output
+
+
+def test_seed_assignment_is_rank_strided_without_loss_or_duplication():
+    from runner.inference import _seeds_for_rank
+
+    seeds = [101, 102, 103, 104, 105, 106]
+    assignments = [_seeds_for_rank(seeds, 4, rank) for rank in range(4)]
+
+    assert assignments == [[101, 105], [102, 106], [103], [104]]
+    assert sorted(seed for lane in assignments for seed in lane) == seeds
+    assert _seeds_for_rank(seeds, 1, 3) == seeds
+
+
+def test_local_seed_resolution_preserves_precedence(monkeypatch, tmp_path):
+    from runner import inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text(
+        '[{"modelSeeds": [11, 12]}, {"modelSeeds": [31, 32]}]',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(inference.random, "randint", lambda *_args: 41)
+
+    configs = SimpleNamespace(input_json_path=str(input_path), seeds=[21, 22])
+    assert inference._resolve_local_inference_seeds(configs) == [21, 22]
+
+    configs.seeds = []
+    assert inference._resolve_local_inference_seeds(configs) == [11, 12]
+
+    input_path.write_text('[{"name": "no-seeds"}]', encoding="utf-8")
+    assert inference._resolve_local_inference_seeds(configs) == [41]
+
+
+def test_rank_zero_resolves_and_broadcasts_seeds_once(monkeypatch, tmp_path):
+    from runner import inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text('[{"modelSeeds": [101, 102]}]', encoding="utf-8")
+    broadcasts = []
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference.dist,
+        "broadcast_object_list",
+        lambda status, src: broadcasts.append((list(status), src)),
+    )
+
+    seeds = inference._resolve_inference_seeds(
+        SimpleNamespace(input_json_path=str(input_path), seeds=[]),
+        size_dp=2,
+    )
+
+    assert seeds == [101, 102]
+    assert broadcasts == [([(True, [101, 102], "")], 0)]
+
+
+@pytest.mark.parametrize(
+    ("seeds", "message"),
+    [
+        ([101, 101], "requires unique seeds"),
+        ([101], "requires at least one seed per lane"),
+    ],
+)
+def test_rank_zero_broadcasts_seed_validation_failure(
+    monkeypatch, tmp_path, seeds, message
+):
+    from runner import inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text('[{"name": "sample"}]', encoding="utf-8")
+    broadcasts = []
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference.dist,
+        "broadcast_object_list",
+        lambda status, src: broadcasts.append((list(status), src)),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        inference._resolve_inference_seeds(
+            SimpleNamespace(input_json_path=str(input_path), seeds=seeds),
+            size_dp=2,
+        )
+
+    assert broadcasts[0][0][0][0] is False
+    assert message in broadcasts[0][0][0][2]
+
+
+def test_nonzero_rank_receives_seeds_without_opening_input(monkeypatch):
+    from runner import inference
+
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=1, local_rank=1),
+    )
+    monkeypatch.setattr(
+        inference,
+        "_resolve_local_inference_seeds",
+        lambda _configs: pytest.fail("nonzero rank must not resolve seeds"),
+    )
+
+    def receive(status, src):
+        assert src == 0
+        status[0] = (True, [101, 102], "")
+
+    monkeypatch.setattr(inference.dist, "broadcast_object_list", receive)
+
+    assert inference._resolve_inference_seeds(object(), size_dp=2) == [101, 102]
+
+
+def test_rank_zero_preprocesses_once_and_broadcasts_path(monkeypatch):
+    from runner import batch_inference
+
+    calls = []
+    broadcasts = []
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "preprocess_input",
+        lambda input_json, **_kwargs: calls.append(input_json) or "updated.json",
+    )
+    monkeypatch.setattr(
+        batch_inference.dist,
+        "broadcast_object_list",
+        lambda status, src: broadcasts.append((list(status), src)),
+    )
+
+    result = batch_inference._preprocess_input_for_runner("input.json")
+
+    assert result == "updated.json"
+    assert calls == ["input.json"]
+    assert broadcasts == [([(True, "updated.json", "")], 0)]
+
+
+def test_rank_zero_broadcasts_preprocessing_failure(monkeypatch):
+    from runner import batch_inference
+
+    broadcasts = []
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "preprocess_input",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("preprocessing unavailable")
+        ),
+    )
+    monkeypatch.setattr(
+        batch_inference.dist,
+        "broadcast_object_list",
+        lambda status, src: broadcasts.append((list(status), src)),
+    )
+
+    with pytest.raises(RuntimeError, match="preprocessing unavailable"):
+        batch_inference._preprocess_input_for_runner("input.json")
+
+    assert broadcasts == [([(False, "", "OSError: preprocessing unavailable")], 0)]
+
+
+def test_nonzero_rank_receives_preprocessing_failure(monkeypatch):
+    from runner import batch_inference
+
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=1, local_rank=1),
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "preprocess_input",
+        lambda *_args, **_kwargs: pytest.fail("nonzero rank must not preprocess"),
+    )
+
+    def receive(status, src):
+        assert src == 0
+        status[0] = (False, "", "OSError: preprocessing unavailable")
+
+    monkeypatch.setattr(batch_inference.dist, "broadcast_object_list", receive)
+
+    with pytest.raises(RuntimeError, match="preprocessing unavailable"):
+        batch_inference._preprocess_input_for_runner("input.json")
+
+
+def test_directory_inputs_are_processed_in_sorted_order(monkeypatch, tmp_path):
+    from runner import batch_inference
+
+    (tmp_path / "b.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "a.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "ignored.txt").write_text("", encoding="utf-8")
+    processed = []
+    inferred = []
+    closed = []
+    runner = SimpleNamespace(configs={}, close=lambda: closed.append(True))
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "get_default_runner",
+        lambda **_kwargs: runner,
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "_preprocess_input_for_runner",
+        lambda input_json, **_kwargs: processed.append(input_json) or input_json,
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "infer_predict",
+        lambda _runner, configs: inferred.append(configs["input_json_path"]),
+    )
+    monkeypatch.setattr(batch_inference.tqdm, "tqdm", lambda values: values)
+
+    batch_inference.inference_jsons(str(tmp_path))
+
+    expected = [str(tmp_path / "a.json"), str(tmp_path / "b.json")]
+    assert processed == expected
+    assert inferred == expected
+    assert closed == [True]
+
+
+def test_distributed_preprocessing_failure_escapes_and_closes_runner(
+    monkeypatch, tmp_path
+):
+    from runner import batch_inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text("[]", encoding="utf-8")
+    closed = []
+    runner = SimpleNamespace(configs={}, close=lambda: closed.append(True))
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=2, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "get_default_runner",
+        lambda **_kwargs: runner,
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "_preprocess_input_for_runner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("preprocessing failed")
+        ),
+    )
+    monkeypatch.setattr(batch_inference.tqdm, "tqdm", lambda values: values)
+
+    with pytest.raises(RuntimeError, match="preprocessing failed"):
+        batch_inference.inference_jsons(str(input_path))
+
+    assert closed == [True]
+
+
+def test_inference_dataloader_keeps_all_records_in_order(monkeypatch):
+    from torch.utils.data import SequentialSampler
+
+    from opendde.data.inference import infer_dataloader
+
+    records = ["first", "second"]
+    monkeypatch.setattr(
+        infer_dataloader,
+        "InferenceDataset",
+        lambda configs: records,
+    )
+    configs = SimpleNamespace(num_workers=0)
+
+    loaders = [infer_dataloader.get_inference_dataloader(configs) for _ in range(2)]
+
+    assert all(isinstance(loader.sampler, SequentialSampler) for loader in loaders)
+    assert [list(loader.sampler) for loader in loaders] == [[0, 1], [0, 1]]
+
+
 def test_get_default_runner_uses_shared_kalign_resolver(monkeypatch):
     from runner import batch_inference
 
@@ -605,9 +985,11 @@ def _patch_cuda_distributed_runner(monkeypatch, inference, *, initialized):
 
 
 def test_failed_runner_destroys_process_group_it_created(monkeypatch):
+    from opendde.distributed.foldcp.config import FoldCPConfig
     from runner import inference
 
     configs = build_inference_config(fill_required_with_null=True)
+    foldcp = FoldCPConfig.from_runtime_args(mode="distributed", size_dp=1, size_cp=2)
     calls = _patch_cuda_distributed_runner(monkeypatch, inference, initialized=False)
 
     def fail_init_basics(self):
@@ -616,7 +998,7 @@ def test_failed_runner_destroys_process_group_it_created(monkeypatch):
     monkeypatch.setattr(inference.InferenceRunner, "init_basics", fail_init_basics)
 
     with pytest.raises(RuntimeError, match="initialization failed"):
-        inference.InferenceRunner(configs)
+        inference.InferenceRunner(configs, foldcp_config=foldcp)
 
     assert calls == {
         "init": [("nccl", inference._DISTRIBUTED_STARTUP_TIMEOUT)],
@@ -625,9 +1007,11 @@ def test_failed_runner_destroys_process_group_it_created(monkeypatch):
 
 
 def test_failed_runner_preserves_preinitialized_process_group(monkeypatch):
+    from opendde.distributed.foldcp.config import FoldCPConfig
     from runner import inference
 
     configs = build_inference_config(fill_required_with_null=True)
+    foldcp = FoldCPConfig.from_runtime_args(mode="distributed", size_dp=1, size_cp=2)
     calls = _patch_cuda_distributed_runner(monkeypatch, inference, initialized=True)
 
     def fail_init_basics(self):
@@ -636,7 +1020,7 @@ def test_failed_runner_preserves_preinitialized_process_group(monkeypatch):
     monkeypatch.setattr(inference.InferenceRunner, "init_basics", fail_init_basics)
 
     with pytest.raises(RuntimeError, match="initialization failed"):
-        inference.InferenceRunner(configs)
+        inference.InferenceRunner(configs, foldcp_config=foldcp)
 
     assert calls == {"init": [], "destroy": 0}
 
@@ -763,6 +1147,152 @@ def test_main_closes_runner_when_inference_fails(monkeypatch):
     assert len(closed) == 1
 
 
+@pytest.mark.parametrize("seeds", [[101, 101], [101]])
+def test_invalid_seed_parallel_request_fails_before_dataloader_or_forward(
+    monkeypatch, tmp_path, seeds
+):
+    from runner import inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text('[{"name": "sample"}]', encoding="utf-8")
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "get_inference_dataloader",
+        lambda **_kwargs: pytest.fail("invalid seeds must fail before data loading"),
+    )
+    runner = SimpleNamespace(
+        foldcp_config=SimpleNamespace(size_dp=2),
+        predict=lambda _data: pytest.fail("invalid seeds must fail before forward"),
+    )
+    configs = SimpleNamespace(input_json_path=str(input_path), seeds=seeds)
+
+    with pytest.raises(ValueError, match="Seed-parallel inference requires"):
+        inference.infer_predict(runner, configs)
+
+
+def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
+    from runner import inference
+
+    class OrderedLoader:
+        dataset = [object(), object()]
+
+        def __iter__(self):
+            for sample_index, sample_name in enumerate(("job-a", "job-b")):
+                data = {
+                    "sample_name": sample_name,
+                    "sample_index": sample_index,
+                    "N_asym": torch.tensor(1),
+                    "N_token": torch.tensor(1),
+                    "N_atom": torch.tensor(1),
+                    "N_msa": torch.tensor(1),
+                    "entity_poly_type": {},
+                    "input_feature_dict": {},
+                }
+                yield [(data, None, "")]
+
+    monkeypatch.setattr(
+        inference,
+        "get_inference_dataloader",
+        lambda **_kwargs: OrderedLoader(),
+    )
+    monkeypatch.setattr(
+        inference, "cleanup_device_memory", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(inference, "seed_everything", lambda **_kwargs: None)
+
+    def run_rank(rank, *, size_dp, foldcp_enabled, seeds):
+        predictions = []
+        dumps = []
+        monkeypatch.setattr(
+            inference,
+            "DIST_WRAPPER",
+            SimpleNamespace(world_size=2, rank=rank, local_rank=rank),
+        )
+        monkeypatch.setattr(
+            inference,
+            "_resolve_inference_seeds",
+            lambda _configs, _size_dp: list(seeds),
+        )
+
+        def predict(data):
+            predictions.append(
+                (
+                    data["sample_name"],
+                    int(data["input_feature_dict"]["inference_seed"]),
+                )
+            )
+            return {}
+
+        runner = SimpleNamespace(
+            device=torch.device("cpu"),
+            error_dir=str(tmp_path / f"errors-{rank}"),
+            foldcp_config=SimpleNamespace(
+                enabled=foldcp_enabled,
+                size_dp=size_dp,
+            ),
+            update_model_configs=lambda _configs: None,
+            predict=predict,
+            dumper=SimpleNamespace(
+                dump=lambda **kwargs: dumps.append((kwargs["pdb_id"], kwargs["seed"]))
+            ),
+        )
+        configs = SimpleNamespace(
+            input_json_path="input.json",
+            deterministic=False,
+            dump_dir=str(tmp_path),
+            skip_amp=SimpleNamespace(
+                confidence_head=False,
+                sample_diffusion=False,
+            ),
+        )
+
+        inference.infer_predict(runner, configs)
+        return predictions, dumps
+
+    dp_results = [
+        run_rank(
+            rank,
+            size_dp=2,
+            foldcp_enabled=False,
+            seeds=[101, 102, 103, 104],
+        )
+        for rank in range(2)
+    ]
+    assert dp_results[0][0] == [
+        ("job-a", 101),
+        ("job-b", 101),
+        ("job-a", 103),
+        ("job-b", 103),
+    ]
+    assert dp_results[1][0] == [
+        ("job-a", 102),
+        ("job-b", 102),
+        ("job-a", 104),
+        ("job-b", 104),
+    ]
+    assert dp_results[0][1] == dp_results[0][0]
+    assert dp_results[1][1] == dp_results[1][0]
+
+    cp_results = [
+        run_rank(rank, size_dp=1, foldcp_enabled=True, seeds=[101]) for rank in range(2)
+    ]
+    assert (
+        cp_results[0][0]
+        == cp_results[1][0]
+        == [
+            ("job-a", 101),
+            ("job-b", 101),
+        ]
+    )
+    assert cp_results[0][1] == cp_results[0][0]
+    assert cp_results[1][1] == []
+
+
 def test_infer_predict_releases_batch_before_seed_cleanup(monkeypatch, tmp_path):
     from runner import inference
 
@@ -814,7 +1344,7 @@ def test_infer_predict_releases_batch_before_seed_cleanup(monkeypatch, tmp_path)
     runner = SimpleNamespace(
         device=torch.device("cpu"),
         error_dir=str(tmp_path / "errors"),
-        foldcp_config=SimpleNamespace(enabled=False),
+        foldcp_config=SimpleNamespace(enabled=False, size_dp=1),
         update_model_configs=lambda _configs: None,
         predict=lambda _data: {},
         dumper=SimpleNamespace(dump=lambda **_kwargs: None),

--- a/tests/test_inference_config.py
+++ b/tests/test_inference_config.py
@@ -2,9 +2,11 @@
 # Copyright (c) 2026 Aureka AI Research
 import inspect
 import os
+import random
 import weakref
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -44,13 +46,17 @@ def test_build_inference_config_applies_model_specific_defaults():
     assert cfg.sample_diffusion.N_step == 200
     assert cfg.confidence.distogram.no_bins == 96
     assert cfg.need_atom_confidence is True
+    assert cfg.seed_batch_size == 1
 
 
-def test_legacy_config_dict_without_device_uses_schema_default():
+def test_legacy_config_dict_uses_new_schema_defaults():
     legacy_config = build_inference_config(fill_required_with_null=True).model_dump()
     legacy_config.pop("device")
+    legacy_config.pop("seed_batch_size")
 
-    assert OpenDDEConfig.model_validate(legacy_config).device == "auto"
+    config = OpenDDEConfig.model_validate(legacy_config)
+    assert config.device == "auto"
+    assert config.seed_batch_size == 1
 
 
 def test_build_inference_config_keeps_cli_overrides_highest_priority():
@@ -94,6 +100,7 @@ def test_get_default_runner_config_build_does_not_mutate_base_defaults(monkeypat
 
     runner = batch_inference.get_default_runner(
         seeds=[101],
+        seed_batch_size=2,
         n_cycle=2,
         n_step=3,
         n_sample=1,
@@ -109,6 +116,7 @@ def test_get_default_runner_config_build_does_not_mutate_base_defaults(monkeypat
     assert runner.configs.model.N_cycle == 2
     assert runner.configs.sample_diffusion.N_step == 3
     assert runner.configs.need_atom_confidence is True
+    assert runner.configs.seed_batch_size == 2
     assert configs_base["model"]["N_cycle"] == 10
     assert configs_base["confidence"]["distogram"]["no_bins"] == 96
 
@@ -377,7 +385,84 @@ def test_world_size_mismatch_fails_before_device_or_model_selection(monkeypatch)
         runner.init_env()
 
 
-def test_predict_help_describes_seed_lanes():
+@pytest.mark.parametrize(
+    ("seed_batch_size", "num_workers", "size_cp", "n_model_seed", "message"),
+    [
+        (0, 0, 1, 1, "seed_batch_size must be >= 1"),
+        (2, 0, 2, 1, "normal P=1 model path only"),
+        (2, 1, 1, 1, "requires num_workers=0"),
+        (2, 0, 1, 2, "requires model.N_model_seed=1"),
+    ],
+)
+def test_invalid_seed_batch_fails_before_device_selection(
+    monkeypatch, seed_batch_size, num_workers, size_cp, n_model_seed, message
+):
+    from opendde.distributed.foldcp.config import FoldCPConfig
+    from runner import inference
+
+    runner = object.__new__(inference.InferenceRunner)
+    runner.foldcp_config = FoldCPConfig.from_runtime_args(
+        mode="distributed" if size_cp > 1 else "single",
+        size_dp=1,
+        size_cp=size_cp,
+    )
+    runner.configs = SimpleNamespace(
+        device="auto",
+        seed_batch_size=seed_batch_size,
+        num_workers=num_workers,
+        model=SimpleNamespace(N_model_seed=n_model_seed),
+    )
+    runner.print = lambda _message: None
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=size_cp, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "select_torch_device",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid seed batching must fail before device selection"
+        ),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        runner.init_env()
+
+
+def test_seed_batch_rejects_tfg_before_device_selection(monkeypatch):
+    from opendde.distributed.foldcp.config import FoldCPConfig
+    from runner import inference
+
+    runner = object.__new__(inference.InferenceRunner)
+    runner.foldcp_config = FoldCPConfig.from_runtime_args(
+        mode="single", size_dp=1, size_cp=1
+    )
+    runner.configs = SimpleNamespace(
+        device="auto",
+        seed_batch_size=2,
+        num_workers=0,
+        sample_diffusion=SimpleNamespace(guidance={"enable": True}),
+    )
+    runner.print = lambda _message: None
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(
+        inference,
+        "select_torch_device",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid seed batching must fail before device selection"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Training-Free Guidance"):
+        runner.init_env()
+
+
+def test_predict_help_describes_seed_batching_and_sharding():
     from click.testing import CliRunner
 
     from runner import batch_inference
@@ -389,13 +474,15 @@ def test_predict_help_describes_seed_lanes():
     )
 
     assert result.exit_code == 0
+    assert "--seed_batch_size" in result.output
+    assert "Maximum seeds per rank-local model batch" in result.output
     assert "--foldcp_size_dp" in result.output
-    assert "Number of independent seed lanes" in result.output
-    assert "normal single-card model path (including seed lanes)" in result.output
+    assert "Number of seed-sharding ranks" in result.output
+    assert "normal model path (including seed batching/sharding)" in result.output
 
 
 def test_seed_assignment_is_rank_strided_without_loss_or_duplication():
-    from runner.inference import _seeds_for_rank
+    from runner.inference import _seed_batches_for_rank, _seeds_for_rank
 
     seeds = [101, 102, 103, 104, 105, 106]
     assignments = [_seeds_for_rank(seeds, 4, rank) for rank in range(4)]
@@ -403,6 +490,17 @@ def test_seed_assignment_is_rank_strided_without_loss_or_duplication():
     assert assignments == [[101, 105], [102, 106], [103], [104]]
     assert sorted(seed for lane in assignments for seed in lane) == seeds
     assert _seeds_for_rank(seeds, 1, 3) == seeds
+
+    seeds = [101, 102, 103, 104, 105, 106, 107]
+    batches = [
+        _seed_batches_for_rank(seeds, 3, rank, seed_batch_size=2) for rank in range(3)
+    ]
+    assert batches == [
+        [[101, 104], [107]],
+        [[102, 105]],
+        [[103, 106]],
+    ]
+    assert sorted(seed for rank in batches for batch in rank for seed in batch) == seeds
 
 
 def test_local_seed_resolution_preserves_precedence(monkeypatch, tmp_path):
@@ -1205,8 +1303,9 @@ def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(inference, "seed_everything", lambda **_kwargs: None)
 
-    def run_rank(rank, *, size_dp, foldcp_enabled, seeds):
+    def run_rank(rank, *, size_dp, foldcp_enabled, seeds, seed_batch_size=1):
         predictions = []
+        forward_batches = []
         dumps = []
         monkeypatch.setattr(
             inference,
@@ -1216,17 +1315,15 @@ def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
         monkeypatch.setattr(
             inference,
             "_resolve_inference_seeds",
-            lambda _configs, _size_dp: list(seeds),
+            lambda _configs, _size_dp, _seed_batch_size=1: list(seeds),
         )
 
-        def predict(data):
-            predictions.append(
-                (
-                    data["sample_name"],
-                    int(data["input_feature_dict"]["inference_seed"]),
-                )
+        def predict_seed_batch(data_batch, batch_seeds, **_kwargs):
+            forward_batches.append((data_batch[0]["sample_name"], tuple(batch_seeds)))
+            predictions.extend(
+                (data_batch[0]["sample_name"], seed) for seed in batch_seeds
             )
-            return {}
+            return [{} for _ in batch_seeds]
 
         runner = SimpleNamespace(
             device=torch.device("cpu"),
@@ -1236,13 +1333,14 @@ def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
                 size_dp=size_dp,
             ),
             update_model_configs=lambda _configs: None,
-            predict=predict,
+            predict_seed_batch=predict_seed_batch,
             dumper=SimpleNamespace(
                 dump=lambda **kwargs: dumps.append((kwargs["pdb_id"], kwargs["seed"]))
             ),
         )
         configs = SimpleNamespace(
             input_json_path="input.json",
+            seed_batch_size=seed_batch_size,
             deterministic=False,
             dump_dir=str(tmp_path),
             skip_amp=SimpleNamespace(
@@ -1252,7 +1350,7 @@ def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
         )
 
         inference.infer_predict(runner, configs)
-        return predictions, dumps
+        return predictions, dumps, forward_batches
 
     dp_results = [
         run_rank(
@@ -1277,6 +1375,31 @@ def test_seed_parallel_and_foldcp_output_ownership(monkeypatch, tmp_path):
     ]
     assert dp_results[0][1] == dp_results[0][0]
     assert dp_results[1][1] == dp_results[1][0]
+
+    batched_results = [
+        run_rank(
+            rank,
+            size_dp=2,
+            foldcp_enabled=False,
+            seeds=[101, 102, 103, 104, 105, 106, 107],
+            seed_batch_size=2,
+        )
+        for rank in range(2)
+    ]
+    assert batched_results[0][2] == [
+        ("job-a", (101, 103)),
+        ("job-b", (101, 103)),
+        ("job-a", (105, 107)),
+        ("job-b", (105, 107)),
+    ]
+    assert batched_results[1][2] == [
+        ("job-a", (102, 104)),
+        ("job-b", (102, 104)),
+        ("job-a", (106,)),
+        ("job-b", (106,)),
+    ]
+    assert batched_results[0][1] == batched_results[0][0]
+    assert batched_results[1][1] == batched_results[1][0]
 
     cp_results = [
         run_rank(rank, size_dp=1, foldcp_enabled=True, seeds=[101]) for rank in range(2)
@@ -1346,12 +1469,13 @@ def test_infer_predict_releases_batch_before_seed_cleanup(monkeypatch, tmp_path)
         error_dir=str(tmp_path / "errors"),
         foldcp_config=SimpleNamespace(enabled=False, size_dp=1),
         update_model_configs=lambda _configs: None,
-        predict=lambda _data: {},
+        predict_seed_batch=lambda _data, seeds, **_kwargs: [{} for _ in seeds],
         dumper=SimpleNamespace(dump=lambda **_kwargs: None),
     )
     configs = SimpleNamespace(
         input_json_path=str(input_path),
         seeds=[1, 2],
+        seed_batch_size=1,
         deterministic=False,
         dump_dir=str(tmp_path),
         skip_amp=SimpleNamespace(confidence_head=False, sample_diffusion=False),
@@ -1379,3 +1503,207 @@ def test_infer_predict_releases_batch_before_seed_cleanup(monkeypatch, tmp_path)
         {"collect_garbage": False},
         {"synchronize": True},
     ]
+
+
+def test_seed_batch_preserves_each_seed_rng_stream_across_records():
+    from runner import inference
+
+    class RandomIterator:
+        def __init__(self):
+            self.index = 0
+            self.setup_draw = torch.rand(1)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.index == 2:
+                raise StopIteration
+            self.index += 1
+            return (
+                self.setup_draw.clone(),
+                random.random(),
+                np.random.random(),
+                torch.rand(2),
+            )
+
+    class RandomLoader:
+        def __iter__(self):
+            return RandomIterator()
+
+    seeds = [101, 202]
+    expected = {}
+    for seed in seeds:
+        inference.seed_everything(seed=seed, deterministic=False)
+        iterator = iter(RandomLoader())
+        expected[seed] = [
+            (next(iterator), torch.rand(3)),
+            (next(iterator), torch.rand(3)),
+        ]
+
+    lanes = inference._seed_data_lanes(RandomLoader(), seeds, deterministic=False)
+    generators = inference._seed_batch_msa_generators(lanes, seeds, torch.device("cpu"))
+    actual = {seed: [] for seed in seeds}
+    for _ in range(2):
+        features = [inference._next_seed_data(lane) for lane in lanes]
+        inference._sync_cpu_msa_generators(
+            lanes,
+            generators,
+            before_model=True,
+            device=torch.device("cpu"),
+        )
+        model_draws = [torch.rand(3, generator=generator) for generator in generators]
+        inference._sync_cpu_msa_generators(
+            lanes,
+            generators,
+            before_model=False,
+            device=torch.device("cpu"),
+        )
+        for seed, feature, model_draw in zip(seeds, features, model_draws):
+            actual[seed].append((feature, model_draw))
+
+    for seed in seeds:
+        for actual_record, expected_record in zip(actual[seed], expected[seed]):
+            actual_features, actual_model_draw = actual_record
+            expected_features, expected_model_draw = expected_record
+            torch.testing.assert_close(
+                actual_features[0], expected_features[0], rtol=0, atol=0
+            )
+            assert actual_features[1:3] == expected_features[1:3]
+            torch.testing.assert_close(
+                actual_features[3], expected_features[3], rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                actual_model_draw, expected_model_draw, rtol=0, atol=0
+            )
+
+
+@pytest.mark.parametrize(
+    ("seeds", "seed_batch_size", "error_lanes", "forward_seeds", "fatal"),
+    [
+        ([101, 202], 2, 0, (101, 202), True),
+        ([101], 1, 0, (101,), False),
+        ([101, 202], 2, 1, (202,), False),
+    ],
+)
+def test_only_seed_batch_oom_is_fatal_and_not_retried(
+    monkeypatch,
+    tmp_path,
+    seeds,
+    seed_batch_size,
+    error_lanes,
+    forward_seeds,
+    fatal,
+):
+    from runner import inference
+
+    class OneRecordLoader:
+        dataset = [object()]
+
+        def __init__(self):
+            self.lane = 0
+
+        def __iter__(self):
+            data = {
+                "sample_name": "sample",
+                "sample_index": 0,
+                "N_asym": torch.tensor(1),
+                "N_token": torch.tensor(1),
+                "N_atom": torch.tensor(1),
+                "N_msa": torch.tensor(1),
+                "entity_poly_type": {},
+                "input_feature_dict": {},
+            }
+            data_error = "test data error" if self.lane < error_lanes else ""
+            self.lane += 1
+            return iter([[(data, None, data_error)]])
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text('[{"name": "sample"}]', encoding="utf-8")
+    calls = []
+    dumps = []
+    cleanup_calls = []
+
+    def predict_seed_batch(_data, seeds, **_kwargs):
+        calls.append(tuple(seeds))
+        raise torch.cuda.OutOfMemoryError("test OOM")
+
+    error_dir = tmp_path / "errors"
+    error_dir.mkdir()
+    runner = SimpleNamespace(
+        device=torch.device("cpu"),
+        error_dir=str(error_dir),
+        foldcp_config=SimpleNamespace(enabled=False, size_dp=1),
+        update_model_configs=lambda _configs: None,
+        predict_seed_batch=predict_seed_batch,
+        dumper=SimpleNamespace(dump=lambda **kwargs: dumps.append(kwargs)),
+    )
+    configs = SimpleNamespace(
+        input_json_path=str(input_path),
+        seeds=seeds,
+        seed_batch_size=seed_batch_size,
+        deterministic=False,
+        dump_dir=str(tmp_path),
+    )
+    monkeypatch.setattr(
+        inference, "get_inference_dataloader", lambda **_kwargs: OneRecordLoader()
+    )
+    monkeypatch.setattr(
+        inference,
+        "cleanup_device_memory",
+        lambda *_args, **kwargs: cleanup_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        inference, "update_inference_configs", lambda configs, _n_token: configs
+    )
+    monkeypatch.setattr(
+        inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+
+    if fatal:
+        with pytest.raises(torch.cuda.OutOfMemoryError, match="test OOM"):
+            inference.infer_predict(runner, configs)
+    else:
+        inference.infer_predict(runner, configs)
+
+    assert calls == [forward_seeds]
+    assert dumps == []
+    assert cleanup_calls == (
+        [{}, {"collect_garbage": False}]
+        if fatal
+        else [{}, {"collect_garbage": False}, {"synchronize": True}]
+    )
+    assert (error_dir / "sample.txt").exists() is not fatal
+
+
+def test_single_process_batch_oom_escapes_and_closes_runner(monkeypatch, tmp_path):
+    from runner import batch_inference
+
+    input_path = tmp_path / "input.json"
+    input_path.write_text("[]", encoding="utf-8")
+    closed = []
+    runner = SimpleNamespace(configs={}, close=lambda: closed.append(True))
+    monkeypatch.setattr(
+        batch_inference,
+        "DIST_WRAPPER",
+        SimpleNamespace(world_size=1, rank=0, local_rank=0),
+    )
+    monkeypatch.setattr(batch_inference, "get_default_runner", lambda **_kwargs: runner)
+    monkeypatch.setattr(
+        batch_inference,
+        "_preprocess_input_for_runner",
+        lambda input_json, **_kwargs: input_json,
+    )
+    monkeypatch.setattr(
+        batch_inference,
+        "infer_predict",
+        lambda *_args: (_ for _ in ()).throw(torch.cuda.OutOfMemoryError("test OOM")),
+    )
+    monkeypatch.setattr(batch_inference.tqdm, "tqdm", lambda values: values)
+
+    with pytest.raises(torch.cuda.OutOfMemoryError, match="test OOM"):
+        batch_inference.inference_jsons(str(input_path), seed_batch_size=2)
+
+    assert closed == [True]

--- a/tests/test_seed_batch.py
+++ b/tests/test_seed_batch.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Aureka AI Research
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from opendde.model.modules.confidence import ConfidenceHead
+from opendde.model.modules.diffusion import DiffusionConditioning, DiffusionModule
+from opendde.model.modules.pairformer import TemplateEmbedder
+from opendde.model.opendde import OpenDDE, update_input_feature_dict
+from opendde.model.seed_batch import (
+    select_seed_batch_features,
+    stack_seed_batch_features,
+)
+
+
+def _seed_features(ref_offset: float = 0.0) -> dict[str, torch.Tensor]:
+    n_token = 3
+    n_atom = 5
+    n_msa = 4
+    n_template = 2
+    return {
+        "restype": torch.zeros(n_token, 32),
+        "profile": torch.zeros(n_token, 32),
+        "deletion_mean": torch.zeros(n_token),
+        "msa": torch.arange(n_msa * n_token).reshape(n_msa, n_token),
+        "msa_mask": torch.ones(n_msa, n_token),
+        "has_deletion": torch.zeros(n_msa, n_token),
+        "deletion_value": torch.zeros(n_msa, n_token),
+        "ref_pos": torch.full((n_atom, 3), ref_offset),
+        "ref_charge": torch.zeros(n_atom),
+        "ref_mask": torch.ones(n_atom),
+        "ref_element": torch.zeros(n_atom, 128),
+        "ref_atom_name_chars": torch.zeros(n_atom, 4, 64),
+        "ref_space_uid": torch.arange(n_atom),
+        "asym_id": torch.zeros(n_token, dtype=torch.long),
+        "template_aatype": torch.zeros(n_template, n_token, dtype=torch.long),
+        "template_distogram": torch.zeros(n_template, n_token, n_token, 39),
+        "template_pseudo_beta_mask": torch.ones(n_template, n_token, n_token),
+        "template_backbone_frame_mask": torch.ones(n_template, n_token, n_token),
+        "template_unit_vector": torch.zeros(n_template, n_token, n_token, 3),
+    }
+
+
+def test_seed_batch_stacks_seed_features_and_shares_templates():
+    features = [_seed_features(1.0), _seed_features(2.0)]
+
+    batched = stack_seed_batch_features(features, [101, 202])
+
+    assert batched["ref_pos"].shape == (2, 5, 3)
+    assert batched["msa"].shape == (2, 4, 3)
+    assert batched["inference_seed"].tolist() == [101, 202]
+    assert batched["template_distogram"] is features[0]["template_distogram"]
+    assert batched["template_aatype"] is features[0]["template_aatype"]
+    assert batched["asym_id"] is features[0]["asym_id"]
+
+
+def test_seed_batch_stacks_templates_only_when_they_differ():
+    features = [_seed_features(), _seed_features()]
+    features[1]["template_distogram"][0, 0, 0, 0] = 1
+
+    batched = stack_seed_batch_features(features, [101, 202])
+
+    assert batched["template_distogram"].shape == (2, 2, 3, 3, 39)
+    assert batched["template_aatype"].shape == (2, 3)
+
+
+def test_seed_batch_rejects_different_topology():
+    features = [_seed_features(), _seed_features()]
+    features[1]["asym_id"][0] = 1
+
+    with pytest.raises(ValueError, match="asym_id"):
+        stack_seed_batch_features(features, [101, 202])
+
+
+def test_singleton_seed_batch_preserves_scalar_feature_shapes():
+    features = _seed_features()
+
+    selected = stack_seed_batch_features([features], [101])
+
+    assert selected["ref_pos"].shape == features["ref_pos"].shape
+    assert selected["inference_seed"].shape == torch.Size([])
+
+
+def test_runner_singleton_seed_batch_keeps_scalar_model_path():
+    from runner.inference import InferenceRunner
+
+    captured = []
+    runner = object.__new__(InferenceRunner)
+
+    def predict(data, **_kwargs):
+        captured.append(data["input_feature_dict"])
+        return {"coordinate": torch.zeros(1, 1, 3)}
+
+    runner.predict = predict
+    predictions = runner.predict_seed_batch(
+        [{"sample_name": "sample", "input_feature_dict": _seed_features()}],
+        [101],
+        msa_generators=[torch.Generator().manual_seed(101)],
+    )
+
+    assert len(predictions) == 1
+    assert captured[0]["ref_pos"].shape == (5, 3)
+    assert captured[0]["inference_seed"].shape == torch.Size([])
+
+
+def test_shared_template_features_broadcast_over_seed_batch():
+    batch_size = 2
+    n_token = 3
+    module = TemplateEmbedder(n_blocks=0, c=4, c_z=3)
+    features = _seed_features()
+    z = torch.zeros(batch_size, n_token, n_token, 3)
+    pair_mask = torch.ones(batch_size, n_token, n_token)
+    multichain_mask = torch.ones(n_token, n_token)
+
+    output = module.single_template_forward(
+        template_id=0,
+        input_feature_dict=features,
+        z=z,
+        pair_mask=pair_mask,
+        multichain_mask=multichain_mask,
+    )
+
+    assert output.shape == (batch_size, n_token, n_token, 4)
+
+
+def test_shared_relative_positions_broadcast_over_seed_batch():
+    batch_size = 2
+    n_token = 3
+    c_z = 4
+    module = DiffusionConditioning(
+        c_z=c_z,
+        c_s=4,
+        c_s_inputs=5,
+        c_noise_embedding=6,
+    )
+    relp = torch.zeros(n_token, n_token, module.relpe.linear_no_bias.in_features)
+    z_trunk = torch.zeros(batch_size, n_token, n_token, c_z)
+
+    pair_z = module.prepare_cache(relp_feature=relp, z_trunk=z_trunk)
+
+    assert pair_z.shape == (batch_size, n_token, n_token, c_z)
+
+
+def test_seed_batched_diffusion_and_confidence_match_scalar_model_stages():
+    torch.manual_seed(9)
+    batch_size = 2
+    n_sample = 2
+    n_atom = 7
+    n_token = 3
+    c_s = 16
+    c_z = 4
+    c_s_inputs = 5
+    atom_to_token_idx = torch.tensor([0, 0, 1, 1, 1, 2, 2])
+    seed_feature_names = {
+        "ref_pos",
+        "ref_charge",
+        "ref_mask",
+        "ref_atom_name_chars",
+        "ref_element",
+        "ref_space_uid",
+    }
+    diffusion_module = DiffusionModule(
+        c_atom=8,
+        c_atompair=4,
+        c_token=8,
+        c_s=c_s,
+        c_z=c_z,
+        c_s_inputs=c_s_inputs,
+        atom_encoder={"n_blocks": 1, "n_heads": 1},
+        transformer={"n_blocks": 1, "n_heads": 1},
+        atom_decoder={"n_blocks": 1, "n_heads": 1},
+    ).eval()
+    confidence_head = ConfidenceHead(
+        n_blocks=1,
+        c_s=c_s,
+        c_z=c_z,
+        c_s_inputs=c_s_inputs,
+        b_pae=6,
+        b_pde=6,
+        b_plddt=5,
+        max_atoms_per_token=4,
+    ).eval()
+    input_features = {
+        "atom_to_token_idx": atom_to_token_idx,
+        "ref_pos": torch.randn(batch_size, n_atom, 3),
+        "ref_charge": torch.randint(-1, 2, (batch_size, n_atom)),
+        "ref_mask": torch.ones(batch_size, n_atom),
+        "ref_atom_name_chars": torch.nn.functional.one_hot(
+            torch.randint(0, 64, (batch_size, n_atom, 4)), 64
+        ).float(),
+        "ref_element": torch.nn.functional.one_hot(
+            torch.randint(0, 10, (batch_size, n_atom)), 128
+        ).float(),
+        "ref_space_uid": atom_to_token_idx.expand(batch_size, -1).clone(),
+        "relp": torch.randn(
+            n_token,
+            n_token,
+            diffusion_module.diffusion_conditioning.relpe.linear_no_bias.in_features,
+        ),
+    }
+    confidence_features = {
+        "distogram_rep_atom_mask": torch.tensor(
+            [1, 0, 1, 0, 0, 1, 0], dtype=torch.bool
+        ),
+        "atom_to_token_idx": atom_to_token_idx,
+        "atom_to_tokatom_idx": torch.tensor([0, 1, 0, 1, 2, 0, 1]),
+    }
+    s_inputs = torch.randn(batch_size, n_token, c_s_inputs)
+    s_trunk = torch.randn(batch_size, n_token, c_s)
+    z_trunk = torch.randn(batch_size, n_token, n_token, c_z)
+    x_noisy = torch.randn(batch_size, n_sample, n_atom, 3)
+    noise_level = torch.rand(batch_size, n_sample) + 1
+
+    with torch.no_grad():
+        batched_coordinate = diffusion_module(
+            x_noisy=x_noisy,
+            t_hat_noise_level=noise_level,
+            input_feature_dict=update_input_feature_dict(dict(input_features)),
+            s_inputs=s_inputs,
+            s_trunk=s_trunk,
+            z_trunk=z_trunk,
+            pair_z=None,
+            p_lm=None,
+            c_l=None,
+            inplace_safe=False,
+        )
+        batched_confidence = confidence_head(
+            input_feature_dict=confidence_features,
+            s_inputs=s_inputs,
+            s_trunk=s_trunk,
+            z_trunk=z_trunk,
+            pair_mask=None,
+            x_pred_coords=batched_coordinate,
+            triangle_attention="torch",
+            triangle_multiplicative="torch",
+            inplace_safe=False,
+        )
+        scalar_results = []
+        for seed_idx in range(batch_size):
+            scalar_features = {
+                name: value[seed_idx] if name in seed_feature_names else value
+                for name, value in input_features.items()
+            }
+            scalar_coordinate = diffusion_module(
+                x_noisy=x_noisy[seed_idx],
+                t_hat_noise_level=noise_level[seed_idx],
+                input_feature_dict=update_input_feature_dict(scalar_features),
+                s_inputs=s_inputs[seed_idx],
+                s_trunk=s_trunk[seed_idx],
+                z_trunk=z_trunk[seed_idx],
+                pair_z=None,
+                p_lm=None,
+                c_l=None,
+                inplace_safe=False,
+            )
+            scalar_confidence = confidence_head(
+                input_feature_dict=confidence_features,
+                s_inputs=s_inputs[seed_idx],
+                s_trunk=s_trunk[seed_idx],
+                z_trunk=z_trunk[seed_idx],
+                pair_mask=None,
+                x_pred_coords=scalar_coordinate,
+                triangle_attention="torch",
+                triangle_multiplicative="torch",
+                inplace_safe=False,
+            )
+            scalar_results.append((scalar_coordinate, scalar_confidence))
+
+    assert batched_coordinate.shape == (batch_size, n_sample, n_atom, 3)
+    torch.testing.assert_close(
+        batched_coordinate,
+        torch.stack([result[0] for result in scalar_results]),
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    for output_idx, batched_output in enumerate(batched_confidence):
+        torch.testing.assert_close(
+            batched_output,
+            torch.stack([result[1][output_idx] for result in scalar_results]),
+            rtol=2e-5,
+            atol=2e-5,
+        )
+
+
+def test_seed_batch_postprocessing_splits_seed_before_sample():
+    batch_size = 2
+    n_sample = 3
+    n_atom = 5
+    n_token = 3
+    calls = []
+
+    def postprocess(**kwargs):
+        seed = int(kwargs["input_feature_dict"]["inference_seed"])
+        kwargs["pred_dict"]["summary_confidence"] = [seed]
+        calls.append((seed, kwargs["pair_z"].shape))
+
+    model = SimpleNamespace(run_post_confidence_outputs_stage=postprocess)
+    input_features = {
+        "inference_seed": torch.tensor([101, 202]),
+        "ref_pos": torch.arange(batch_size * n_atom * 3).reshape(batch_size, n_atom, 3),
+        "is_ligand": torch.zeros(n_atom),
+        "template_aatype": torch.zeros(batch_size, n_token, dtype=torch.long),
+    }
+    pred_dict = {
+        "coordinate": torch.zeros(batch_size, n_sample, n_atom, 3),
+        "contact_probs": torch.zeros(batch_size, n_token, n_token),
+        "plddt": torch.zeros(batch_size, n_sample, n_atom, 2),
+        "pae": torch.zeros(batch_size, n_sample, n_token, n_token, 2),
+        "pde": torch.zeros(batch_size, n_sample, n_token, n_token, 2),
+        "resolved": torch.zeros(batch_size, n_sample, n_atom, 2),
+    }
+    pair_z = torch.zeros(batch_size, n_token, n_token, 4)
+
+    predictions = OpenDDE.postprocess_seed_batch(
+        model,
+        pred_dict=pred_dict,
+        input_feature_dict=input_features,
+        pair_input_feature_dict=input_features,
+        pair_z=pair_z,
+        N_cycle=1,
+    )
+
+    assert [prediction["summary_confidence"] for prediction in predictions] == [
+        [101],
+        [202],
+    ]
+    assert all(
+        prediction["coordinate"].shape == (n_sample, n_atom, 3)
+        for prediction in predictions
+    )
+    assert calls == [(101, (n_token, n_token, 4)), (202, (n_token, n_token, 4))]
+    selected = select_seed_batch_features(input_features, 0, batch_size)
+    assert selected["template_aatype"] is input_features["template_aatype"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -197,6 +197,60 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(sampled["msa"].shape[0], 2)
         self.assertTrue(torch.all(sampled["msa"].ne(gap_token).any(dim=-1)))
 
+    def test_seed_batched_msa_sampling_matches_independent_streams(self):
+        gap_token = 31
+        msa = torch.tensor(
+            [
+                [0, 1, 2],
+                [3, 4, 5],
+                [6, 7, 8],
+                [9, 10, 11],
+                [gap_token, gap_token, gap_token],
+            ]
+        )
+        scalar_features = [
+            {
+                "msa": msa.clone(),
+                "has_deletion": torch.zeros(5, 3),
+                "deletion_value": torch.zeros(5, 3),
+            }
+            for _ in range(2)
+        ]
+        batched_features = {
+            name: torch.stack([features[name] for features in scalar_features])
+            for name in scalar_features[0]
+        }
+        batched_generators = [
+            torch.Generator().manual_seed(seed) for seed in (101, 202)
+        ]
+        scalar_generators = [torch.Generator().manual_seed(seed) for seed in (101, 202)]
+
+        for _ in range(2):
+            actual = subsample_msa_feature_dict_valid_first(
+                feat_dict=batched_features,
+                dim_dict={name: -2 for name in batched_features},
+                num_msa=3,
+                gap_token=gap_token,
+                generators=batched_generators,
+            )
+            expected = [
+                subsample_msa_feature_dict_valid_first(
+                    feat_dict=features,
+                    dim_dict={name: -2 for name in features},
+                    num_msa=3,
+                    gap_token=gap_token,
+                    generators=[generator],
+                )
+                for features, generator in zip(scalar_features, scalar_generators)
+            ]
+            for name in actual:
+                torch.testing.assert_close(
+                    actual[name],
+                    torch.stack([features[name] for features in expected]),
+                    rtol=0,
+                    atol=0,
+                )
+
     def tearDown(self):
         elapsed_time = time.time() - self._start_time
         print(f"Test {self.id()} took {elapsed_time:.6f}s")


### PR DESCRIPTION
## Summary

- Add `--seed_batch_size` for true rank-local batching of independent inference seeds.
- Use one scheduler for single-GPU and multi-GPU seed execution: ranks receive `seeds[rank::D]`, then run chunks of at most `B` through the same model path.
- Preserve per-seed featurization, MSA sampling, diffusion RNG streams, samples, and existing output layout.
- Keep `B=1` as the compatibility default and reject unsupported `B>1` combinations before model loading.

## Changes

- Stack only seed-varying features on a leading seed dimension while sharing invariant topology and template tensors.
- Batch the normal MSA, trunk, diffusion, and confidence stages, then split seeds before existing scalar postprocessing and dumping.
- Support partial final batches and compose local batching with `D>1, P=1` seed sharding without a separate single-GPU path.
- Reject batched Fold-CP, hybrid `D x P`, worker-based featurization, nested `N_model_seed>1`, and Training-Free Guidance for `B>1`.
- Document CLI semantics, constraints, reproduction commands, and local qualification in the SPEC and IMPL.

## Validation

- `335 passed, 4 deselected, 44 subtests passed` (`pytest tests -q -m 'not network'`).
- `ruff check .`, `ruff format --check .`, and `git diff --check` passed.
- BF16 GPU runs passed for single-GPU `B=1/B>1`, a partial tail, `D=2/3/4` with `B=2`, and existing Fold-CP `P=2/3/4, B=1` on three RTX 3090s plus one RTX 4090.
- Five real MSA cases were capacity-tested on both GPU types; the largest fitting widths ranged from `B=2` to `B=10` on 24 GiB and `B=4` to `B=21` on 48 GiB, with each next explicit width verified to OOM without retry.
- A 7R6R control at 10 recycles / 200 diffusion steps improved two-seed wall time by 1.081x on RTX 3090 and 1.148x on RTX 4090, with about 3.0 GiB additional peak memory at `B=2`.
- 7EOW with the ABAG checkpoint produced all requested outputs across world sizes 1-4; its same-GPU `B=2` run fit the 48 GiB card but was memory-bound and did not improve wall time.
- Output cardinality, CIF schema, atom identity/order, and finite values passed. Per-seed RNG component tests match scalar streams; the IMPL records observed non-bitwise BF16 end-to-end deltas and the full timing/memory matrix.
